### PR TITLE
feat(ci): add automated PR review agent with rule-weight feedback loop

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -1,0 +1,255 @@
+# Claude PR review agent
+
+An automated pull request reviewer that applies a written rulebook and gets
+quieter over time about the rules people keep dismissing.
+
+## How it works
+
+Every pull request runs three steps:
+
+1. **Prepare** — the workflow computes the diff against the merge base and
+   writes it to `.claude-review/pr.diff`.
+2. **Review** — `scripts/openrouter-review.mjs` sends the diff and a compact
+   rules digest to a free model on OpenRouter and writes structured findings to
+   `.claude-review/findings.json`.
+3. **Post** — `scripts/post-review.mjs` validates those findings, gates them
+   against the learned per-rule weights, maps them onto lines GitHub will
+   accept, and posts one review.
+
+Step 2 is the only provider-specific part. Anything that writes
+`findings.json` in the schema below works — the shipped alternative is
+`workflows/claude-pr-review.yml`, which uses `anthropics/claude-code-action@v1`
+and can read the surrounding source rather than only the diff. Swapping
+providers does not touch the rulebook, the gating, or the feedback loop.
+
+The split between step 2 and step 3 is the whole design. Claude decides *what*
+is wrong; the script decides *what gets said*. That keeps the comment cap, the
+confidence thresholds, and the mute list as code rather than as polite requests
+in a prompt, and it means every posted comment carries a machine-readable
+marker tying it back to a rule.
+
+## The feedback loop
+
+Each comment ends with a hidden marker:
+
+```html
+<!-- claude-review rule=SEC-001 fid=k3f9q2m conf=0.85 score=0.6 sev=blocker -->
+```
+
+Weekly, `scripts/tune-rules.mjs` walks recent PRs, finds those markers, and
+works out how humans actually responded:
+
+| Signal | Outcome |
+| --- | --- |
+| 👎 reaction | rejected |
+| 👍 reaction | accepted |
+| Reply matching a dismissal phrase ("false positive", "by design", …) | rejected |
+| Reply matching an agreement phrase ("good catch", "fixed", …) | accepted |
+| The flagged code changed after the comment (comment went outdated) | accepted |
+| PR closed with no response at all | ignored (weak negative) |
+| PR still open with no response | not scored yet |
+
+Each rule carries a Beta posterior over "does this rule produce comments people
+act on". The prior is worth three observations centred on 0.7 — a hand-written
+rule is presumed useful, but not strongly. The posterior mean is the rule's
+**weight**.
+
+A finding is posted when `confidence × weight` clears a per-severity gate:
+
+| Severity | Gate |
+| --- | --- |
+| blocker | 0.30 |
+| major | 0.36 |
+| minor | 0.42 |
+| nit | 0.50 |
+
+Nits have to be more certain than blockers to earn a comment, which is the
+right trade when reviewer attention is the scarce resource.
+
+As evidence accumulates, rules change state:
+
+- **active** — normal.
+- **probation** — weight below 0.5 with at least 5 observations. Only blocker
+  and major findings are posted.
+- **muted** — weight below 0.3 with at least 8 observations. Silent.
+
+Two things stop this from ratcheting one way forever:
+
+- **Decay.** Observations lose half their weight every 90 days, so the rulebook
+  reflects how a rule behaves now, not how it behaved before someone rewrote it.
+- **Exploration.** A muted rule is still tried on roughly 10% of PRs — chosen by
+  a deterministic hash of the rule ID and PR number, so re-runs on the same PR
+  agree with each other. Those comments say they are a re-test, and they bypass
+  the score gate (a muted rule's weight could never clear it, so without the
+  bypass the mechanism would never fire). This is how a rule that was genuinely
+  fixed earns its way back without anyone intervening.
+
+Weights are recomputed from the full ledger on every run, never incremented in
+place. The job is therefore idempotent, and a mis-scored outcome can be fixed by
+editing `feedback-ledger.json` by hand and re-running.
+
+The tuning job opens a PR rather than pushing. Somebody always sees which rules
+are about to go quiet, and why.
+
+## Files
+
+| Path | What it is |
+| --- | --- |
+| `review-rules.md` | The rulebook. Human-written. Edit this. |
+| `rules.json` | Learned state: weight, status, and evidence per rule. Machine-written. |
+| `feedback-ledger.json` | Every scored comment. The source of truth for weights. |
+| `findings.schema.json` | Contract between the model and the posting script. |
+| `scripts/openrouter-review.mjs` | Produces findings via OpenRouter free models. |
+| `scripts/post-review.mjs` | Gates findings and posts the review. |
+| `scripts/tune-rules.mjs` | The learning loop. |
+| `scripts/sync-rules.mjs` | Keeps the markdown and the JSON in agreement. |
+| `scripts/lib/scoring.mjs` | Pure scoring logic. All of it unit tested. |
+| `scripts/lib/github.mjs` | Dependency-free GitHub REST/GraphQL client. |
+| `scripts/lib/openrouter.mjs` | Model discovery, diff chunking, JSON recovery. |
+
+The scripts have no npm dependencies. They run on the Node 20 already present
+on `ubuntu-latest`, so there is no install step, no lockfile to maintain, and no
+supply-chain surface on a workflow that runs against every PR.
+
+## Setup
+
+1. **Create an OpenRouter API key** at
+   [openrouter.ai/keys](https://openrouter.ai/keys).
+
+2. **Set the privacy settings before you use it.** In OpenRouter's privacy
+   settings there are separate controls for paid and free models governing
+   whether requests may be routed to providers that train on your data. Free
+   models are free largely because that routing is permitted. Turn training off
+   for free models. OpenRouter itself does not store prompts unless you opt in
+   to logging, but its policy does not bind the upstream provider.
+
+   This matters more here than in most codebases. The reviewer sends diff
+   content, and diffs of clinical code contain table names, field names and
+   sometimes fixture data. Decide deliberately what may leave your
+   infrastructure before switching this on. If the answer is "nothing", use the
+   Claude workflow with an API key instead — paid API traffic is not trained on.
+
+3. **Add the key** as a repository or organisation secret named
+   `OPENROUTER_API_KEY` (Settings → Secrets and variables → Actions).
+
+4. **Optionally pin your preferred models** as a repository *variable* — not a
+   secret — named `OPENROUTER_MODELS`, comma-separated, best first:
+
+   ```
+   deepseek/deepseek-chat:free,qwen/qwen-2.5-coder-32b-instruct:free
+   ```
+
+   Leave it unset and the script picks the largest-context free models
+   available at that moment. Free models are retired often, so this is a
+   preference, not a pin: any listed model that is no longer free is skipped
+   rather than causing a failure.
+
+5. **Copy `.github/workflows/` and `.github/review/`** into your repository. If
+   you are using OpenRouter, delete `workflows/claude-pr-review.yml` — leaving
+   both means every PR gets reviewed twice.
+
+6. **Consider putting $10 of credit on the OpenRouter account.** The free tier
+   allows 20 requests per minute and 50 per day; a one-off $10 top-up raises the
+   daily cap to 1,000 and is not consumed by `:free` models. At 4 requests per
+   PR, 50/day is roughly a dozen pull requests before the reviewer goes quiet
+   for the rest of the day. On a team your size that ceiling will bite.
+
+7. **Open a test PR** with something obviously wrong in it — a string-concatenated
+   SQL query is a good probe — and confirm the review appears.
+
+`rules.json` ships seeded and ready; nothing else needs configuring.
+
+### Free-tier budget
+
+Each batch of files is one OpenRouter request. `MAX_REQUESTS` in the workflow
+caps how many a single PR may spend, defaulting to 4. Files that do not fit are
+named in the summary comment rather than silently dropped, so you can always
+tell the difference between "reviewed and clean" and "never looked at".
+
+Raise `MAX_REQUESTS` if you have topped up and want deeper coverage on large
+PRs; lower it to 2 if you are staying on 50/day.
+
+## Day-to-day
+
+**React to the comments.** 👍 and 👎 are the highest-quality signal the loop
+gets, and they are the only one that is unambiguous. Everything else is
+inference. Ask the team to spend the two seconds.
+
+**Read the weekly tuning PR** before merging it. It lists which rules moved,
+which are muted, and how much evidence sits behind each move.
+
+**Adding a rule:** add it to `review-rules.md`, then run
+
+```bash
+node .github/review/scripts/sync-rules.mjs --write
+```
+
+The `validate` job fails any PR where the two files disagree, so they cannot
+drift apart.
+
+**Removing a rule:** delete it from `review-rules.md` and run the same command.
+Its history moves into the `retired` block rather than being lost.
+
+**Tuning by hand:** the knobs are `defaults.maxCommentsPerPR` and
+`defaults.explorationPercent` in `rules.json`, and `SEVERITY_GATES` in
+`scripts/lib/scoring.mjs`.
+
+**Watch `GEN-000`.** That is the bucket for real problems no rule covers. When
+the same kind of `GEN-000` finding keeps getting accepted, that is a rule asking
+to be written.
+
+## Running it locally
+
+```bash
+# See what the loop would do without writing anything
+GITHUB_TOKEN=$(gh auth token) REPO=owner/name \
+  node .github/review/scripts/tune-rules.mjs --days 60 --dry-run
+
+# Tests
+node --test '.github/review/scripts/test/*.test.mjs'
+```
+
+## Deliberate limits
+
+**It never blocks a merge.** The review posts as `COMMENT`, and
+`post-review.mjs` exits zero even when it fails. Set
+`REQUEST_CHANGES_ON_BLOCKER: "1"` in the workflow if you want blockers to
+request changes — but note that a review from `GITHUB_TOKEN` does not satisfy a
+branch protection "required approvals" rule either way.
+
+**Fork PRs on public repositories are skipped.** GitHub withholds secrets from
+those runs, so the review step cannot authenticate. This is a GitHub security
+boundary, not something to work around.
+
+**Large diffs are truncated** at 400 KB, and the summary says so when it
+happens. Lockfiles, snapshots, minified output, and build directories are
+excluded from the diff before that limit applies.
+
+**Feedback is sparse and noisy.** "Ignored" is weak evidence — someone may have
+agreed and simply not clicked anything. That is why it counts for 40% of a
+rejection, why muting needs eight observations, and why decay and exploration
+exist. Treat the weights as a way to keep the bot quiet about things your team
+demonstrably does not care about, not as a measure of whether a rule is correct.
+
+**The OpenRouter reviewer only sees the diff.** It cannot open the surrounding
+file, grep for the caller, or check whether a guard exists elsewhere in the
+repo, because a chat completion is one shot with no tools. Rules that need
+repo-wide context — SEC-002 (is this route actually behind a guard?), DATA-005
+(does an index exist?), TS-005 (is there already a helper?) — will miss more
+often than the rest. Expect the feedback loop to push those toward probation,
+and read that as a limitation of the provider rather than of the rule. The
+Claude workflow, which has `Read` and `Grep`, does noticeably better on exactly
+those.
+
+**Free models are weaker at line numbers.** Counting new-file line numbers out
+of a diff hunk is genuinely hard for a small model. `post-review.mjs` checks
+every line against the diff and demotes anything out of range into the summary,
+so a miscount degrades into a less convenient comment rather than a failed
+review — but expect a share of findings to land in the summary rather than
+inline.
+
+**It is not reinforcement learning in the training sense.** No model weights are
+updated. It is a bandit-flavoured control loop over which rules are allowed to
+speak. That is the version that works at the volume of feedback a real team
+produces; a fine-tuning pipeline would need orders of magnitude more labelled
+data than a repository generates.

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -206,7 +206,7 @@ GITHUB_TOKEN=$(gh auth token) REPO=owner/name \
   node .github/review/scripts/tune-rules.mjs --days 60 --dry-run
 
 # Tests
-node --test '.github/review/scripts/test/*.test.mjs'
+node --test .github/review/scripts/test/*.test.mjs
 ```
 
 ## Deliberate limits

--- a/.github/review/feedback-ledger.json
+++ b/.github/review/feedback-ledger.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Every review comment the tuning job has scored, keyed by GitHub comment id. This is the source of truth for rule weights - rules.json is recomputed from it on every run. Safe to edit by hand to correct a mis-scored outcome.",
+  "lastRunAt": null,
+  "entries": {}
+}

--- a/.github/review/findings.schema.json
+++ b/.github/review/findings.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/intelehealth/.github/review/findings.schema.json",
+  "title": "Claude PR review findings",
+  "description": "Structured output the review agent writes to .claude-review/findings.json. post-review.mjs validates against this before anything is posted.",
+  "type": "object",
+  "required": ["summary", "findings"],
+  "additionalProperties": false,
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2000,
+      "description": "Plain-English verdict on the PR as a whole."
+    },
+    "findings": {
+      "type": "array",
+      "maxItems": 60,
+      "items": { "$ref": "#/$defs/finding" }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "required": ["ruleId", "file", "line", "severity", "confidence", "title", "body"],
+      "additionalProperties": false,
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "pattern": "^[A-Z]+-[0-9]+$",
+          "description": "Must exist in rules.json."
+        },
+        "file": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path exactly as it appears in the diff."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Line number in the new version of the file."
+        },
+        "endLine": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "End of the range, for multi-line findings. Defaults to line."
+        },
+        "severity": { "enum": ["blocker", "major", "minor", "nit"] },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Honest probability a senior engineer would agree this is real."
+        },
+        "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+        "body": { "type": "string", "minLength": 1, "maxLength": 4000 },
+        "suggestion": {
+          "type": "string",
+          "maxLength": 2000,
+          "description": "Exact replacement code for line..endLine. No code fences."
+        }
+      }
+    }
+  }
+}

--- a/.github/review/review-rules.md
+++ b/.github/review/review-rules.md
@@ -1,0 +1,318 @@
+# PR Review Rulebook
+
+This is the instruction set the automated reviewer applies to every pull request.
+It is meant to be edited by humans. Treat it as a living document: when the bot
+misses something a human caught in review, add a rule; when a rule keeps firing
+on non-issues, the tuning job will mute it and open a PR telling you so.
+
+## How the reviewer uses this file
+
+Every finding the bot reports must cite one of the rule IDs below. That citation
+is what makes the feedback loop work — `tune-rules.mjs` groups outcomes by rule
+ID, so a rule that keeps getting dismissed can be identified and muted without
+touching the rules that are pulling their weight.
+
+Severities:
+
+- **blocker** — would cause data loss, a security hole, a patient-safety issue,
+  or a production outage. Should not merge.
+- **major** — a real bug or a design decision that will be expensive to undo.
+- **minor** — a genuine issue with a bounded cost.
+- **nit** — worth mentioning, never worth blocking on.
+
+The bot is instructed to stay silent below 60% confidence, and to skip anything
+a linter or formatter already enforces. Reviewer attention is the scarce
+resource being protected here, not model tokens.
+
+## Scope
+
+Review only lines the PR adds or modifies. Reading surrounding code for context
+is expected; reporting pre-existing issues in untouched code is not.
+
+---
+
+## SEC — Security
+
+**SEC-001 · blocker · Injection via unparameterised query.** String
+concatenation or template literals building SQL, or user input reaching a Mongo
+query operator position. Sequelize `replacements`/`bind`, or an explicit
+parameterised query, is required. In Mongoose, reject any path where a
+request-supplied object can land where a query operator is expected — that is
+how `$ne`/`$gt` operator injection gets in.
+
+**SEC-002 · blocker · Missing authentication or authorisation on a new route.**
+A new Express route, NestJS controller method, or Socket.IO event handler that
+does not sit behind the project's auth guard/middleware, or that authenticates
+the caller but never checks that the caller is allowed to touch *this* record.
+Broken object-level authorisation is the most common real vulnerability in this
+kind of codebase; flag it explicitly rather than assuming a guard exists further
+up.
+
+**SEC-003 · blocker · Secret, key, or credential committed.** API keys, tokens,
+private keys, connection strings with embedded passwords, or `.env` files in the
+diff. Applies to test fixtures too.
+
+**SEC-004 · major · Unvalidated request input.** A handler reading `req.body`,
+`req.query`, or `req.params` and using it without schema validation
+(`class-validator` DTO, Joi, Zod, or the project's equivalent). Type assertions
+in TypeScript are not validation — `as CreateUserDto` proves nothing at runtime.
+
+**SEC-005 · major · Mass assignment.** Spreading a request body straight into a
+model create/update (`Model.create({ ...req.body })`, `Object.assign(user,
+req.body)`). Fields like `role`, `isAdmin`, `verified`, or `tenantId` become
+attacker-controlled.
+
+**SEC-006 · major · Unsafe rendering or DOM injection.** `dangerouslySetInnerHTML`,
+Angular `bypassSecurityTrustHtml`, Vue `v-html`, or direct `innerHTML` assignment
+with data that is not provably static or sanitised.
+
+**SEC-007 · major · Weak or hand-rolled cryptography.** MD5/SHA-1 for passwords,
+`Math.random()` for tokens or IDs, custom encryption, or JWTs verified without
+checking the algorithm and expiry.
+
+**SEC-008 · major · Overly permissive CORS or cookie flags.** `origin: '*'`
+alongside credentials, or session cookies missing `httpOnly`, `secure`, or
+`sameSite`.
+
+**SEC-009 · minor · Dependency added with no obvious need.** A new runtime
+dependency in `package.json` that duplicates something already present or that
+is doing work a few lines of code would do. Note it; do not block.
+
+---
+
+## PHI — Patient and personal data
+
+These matter more here than in a typical codebase. Apply them to anything that
+looks like patient identity, clinical notes, visit records, prescriptions,
+diagnoses, phone numbers, or location.
+
+**PHI-001 · blocker · Patient-identifying data in logs.** `console.log`,
+logger calls, or error messages that include a patient name, identifier,
+phone number, address, or clinical detail. Log an opaque ID instead.
+
+**PHI-002 · blocker · Patient data sent to a third party.** New calls to an
+analytics, monitoring, crash-reporting, or AI service whose payload could carry
+PHI. Includes Sentry `extra`/`context` and analytics event properties.
+
+**PHI-003 · major · Patient data in client-side storage.** `localStorage`,
+`sessionStorage`, IndexedDB, or `AsyncStorage` holding clinical or identifying
+data without a clear, deliberate reason and a cleanup path on logout.
+
+**PHI-004 · major · Over-broad response payload.** An endpoint returning a whole
+patient or user document where the caller needs a few fields. Call out the
+specific fields that should not be crossing the wire.
+
+**PHI-005 · minor · Missing audit trail on a sensitive action.** Create, update,
+export, or delete of clinical records without a corresponding audit log entry,
+where the codebase has an audit mechanism.
+
+---
+
+## DATA — Databases, ORMs, migrations
+
+**DATA-001 · blocker · Destructive or irreversible migration.** A migration that
+drops a column or table, or changes a type in a way that loses data, without a
+documented backfill and rollback path. Also flag migrations with no `down`.
+
+**DATA-002 · blocker · Multi-step write with no transaction.** Two or more
+related writes that must succeed or fail together, issued without a Sequelize
+transaction or a Mongo session. Partial writes here mean corrupted clinical
+records.
+
+**DATA-003 · major · N+1 query.** A query inside a loop or `.map()` over a
+result set. In Sequelize, prefer `include`; in Mongoose, prefer `populate` or a
+single `$in` query.
+
+**DATA-004 · major · Unbounded query.** `findAll` / `find({})` with no `limit`,
+no pagination, and no obvious bound on row count. It works on a dev database and
+falls over on a real one.
+
+**DATA-005 · major · New query pattern with no supporting index.** A filter or
+sort on fields that are unlikely to be indexed, with no accompanying migration
+or schema index. Say which index you would add.
+
+**DATA-006 · minor · Schema change without a corresponding migration.** A model
+or entity definition changed with nothing in the migrations directory.
+
+**DATA-007 · minor · Connection or session not released.** A transaction,
+session, or connection acquired without a `finally` that releases it on the
+error path.
+
+---
+
+## API — Interfaces and contracts
+
+**API-001 · major · Breaking change to a published contract.** A removed or
+renamed field, a changed type, a narrowed enum, or a newly required request
+field on an endpoint or event that clients already use — with no versioning and
+no deprecation path. Mobile clients in particular cannot be upgraded in lockstep.
+
+**API-002 · major · Wrong or misleading status codes.** Errors returned as
+`200`, validation failures as `500`, or a `catch` that swallows everything into
+one generic status.
+
+**API-003 · minor · Inconsistent response shape.** A new endpoint whose success
+or error envelope differs from the pattern the rest of the service uses.
+
+**API-004 · minor · Undocumented endpoint.** A new public route with no Swagger/
+OpenAPI decorator or doc entry, in a service that otherwise documents its routes.
+
+---
+
+## ASYNC — Async, errors, and control flow
+
+**ASYNC-001 · blocker · Unhandled promise rejection path.** An `async` function
+called without `await` or `.catch()` where a rejection would be silently lost, or
+an `async` callback passed to an API that ignores the returned promise
+(`setInterval`, `forEach`, Express handlers without an error wrapper).
+
+**ASYNC-002 · major · Swallowed error.** `catch {}`, `catch (e) { console.log(e) }`
+with no rethrow or recovery, or a catch that returns a success value. If the
+error is genuinely expected, that reasoning belongs in a comment.
+
+**ASYNC-003 · major · Awaiting in a loop where the work is independent.**
+Sequential `await` inside a `for` loop over items with no dependency between
+iterations. Use `Promise.all` — bounded with a concurrency limit if the list can
+be large.
+
+**ASYNC-004 · major · Race condition on shared state.** Two async paths reading
+and writing the same in-memory map, cache entry, or record with no locking,
+compare-and-set, or atomic update.
+
+**ASYNC-005 · minor · External call with no timeout or retry policy.** `fetch`,
+`axios`, or a database call to a remote service with no timeout, in code where a
+hang would block a request path.
+
+---
+
+## RT — Realtime: Socket.IO and WebRTC
+
+**RT-001 · blocker · Socket event handler without authentication.** A
+`socket.on(...)` handler that trusts a client-supplied user or room ID instead of
+the identity established at connection time.
+
+**RT-002 · major · Listener registered without cleanup.** `socket.on`,
+`addEventListener`, `RTCPeerConnection` event handlers, or subscriptions added
+with no matching removal on disconnect, unmount, or teardown. This is the usual
+source of a slow memory leak and of handlers firing twice.
+
+**RT-003 · major · Peer connection or media track not closed.** An
+`RTCPeerConnection`, `MediaStream`, or track opened without a path that closes
+it and stops the tracks — including on the error and early-return paths. On
+mobile this leaves the camera light on.
+
+**RT-004 · major · Broadcast to a room without an authorisation check.**
+Emitting to a room derived from user input, or joining a room without verifying
+the user belongs to it.
+
+**RT-005 · minor · No reconnection or degraded-network handling.** New realtime
+code that assumes a stable connection. Relevant for low-bandwidth field use.
+
+---
+
+## FE — Frontend: React, Angular, Vue, Ionic, React Native
+
+**FE-001 · major · Effect with a wrong or missing dependency array.** A
+`useEffect`/`useCallback`/`useMemo` whose dependencies do not match what it
+reads, causing a stale closure or an infinite render loop.
+
+**FE-002 · major · State update after unmount.** An async result written to
+state with no cancellation, `AbortController`, or mounted guard.
+
+**FE-003 · major · Subscription without teardown.** An RxJS subscription in
+Angular with no `takeUntil`/`async` pipe, a Vue watcher never stopped, or a
+React effect that returns no cleanup where it should.
+
+**FE-004 · minor · Expensive work on every render.** Non-trivial computation,
+object/array literals, or new function identities passed as props into memoised
+children, causing avoidable re-renders.
+
+**FE-005 · minor · Unkeyed or index-keyed list.** `key={index}` on a list that
+can reorder, insert, or delete.
+
+**FE-006 · minor · Accessibility gap on a new interactive element.** A clickable
+`div`, a form control with no label, or an icon-only button with no accessible
+name.
+
+**FE-007 · minor · User-facing string hardcoded.** New copy inserted directly
+rather than through the project's i18n mechanism, in a codebase that has one.
+
+---
+
+## TS — TypeScript and code health
+
+**TS-001 · major · `any` or a type assertion hiding a real mismatch.** `any`,
+`as unknown as X`, or a non-null assertion `!` used to silence the compiler
+rather than because the invariant is genuinely known. Say what the correct type
+is.
+
+**TS-002 · major · Missing null/undefined handling.** A value that can be
+`undefined` — an optional field, an array `find`, an env var, a `JSON.parse`
+result — used without a check.
+
+**TS-003 · minor · `@ts-ignore` / `eslint-disable` with no justification.**
+Suppressions are fine when explained; unexplained ones accumulate.
+
+**TS-004 · minor · Dead or unreachable code.** Commented-out blocks, unused
+exports, or branches that cannot be taken, introduced by this PR.
+
+**TS-005 · minor · Duplicated logic.** The same non-trivial logic added in a
+second place where an existing helper would do, or where a helper is now
+warranted.
+
+---
+
+## TEST — Tests
+
+**TEST-001 · major · Bug fix with no regression test.** A PR that fixes
+described broken behaviour without a test that would have caught it.
+
+**TEST-002 · minor · New business logic with no test coverage.** A new service
+method, reducer, or non-trivial pure function with no accompanying test, in a
+repo that has a test suite.
+
+**TEST-003 · minor · Flaky test pattern.** A test depending on wall-clock time,
+network access, a fixed sleep, or execution order.
+
+**TEST-004 · minor · Assertion that cannot fail.** `expect(true).toBe(true)`,
+a snapshot committed without review, or a test with no assertion at all.
+
+---
+
+## OPS — Configuration, deployment, observability
+
+**OPS-001 · major · Configuration hardcoded.** A URL, timeout, feature flag,
+region, or limit written inline where the project uses config or environment
+variables. Especially anything that differs between environments.
+
+**OPS-002 · major · New env var with no default, no validation, and no docs.**
+It will work locally and crash on deploy.
+
+**OPS-003 · minor · Missing observability on a new critical path.** A new
+integration, job, or payment/clinical workflow with no logging or metric at its
+failure points.
+
+**OPS-004 · minor · Backwards-incompatible change with no deploy ordering
+note.** A change that requires the migration, the API, and the client to ship in
+a particular order, with nothing in the PR description saying so.
+
+---
+
+## GEN — Uncategorised
+
+**GEN-000 · minor · Issue not covered by an existing rule.** Used when the bot
+believes it has found a real problem that no rule above describes. The finding
+body must propose the rule that would cover it. Review these periodically — a
+GEN-000 that recurs is a rule waiting to be written.
+
+---
+
+## Editing this file
+
+Adding a rule: add the entry above, then add a matching entry to
+`.github/review/rules.json` with `state: "active"` and `weight: 0.7`. The
+`validate-rules` step in the tuning workflow fails if the two files disagree, so
+neither can drift.
+
+Removing a rule: delete it from both files. Historical stats for that rule are
+kept in `rules.json`'s `retired` block for reference.

--- a/.github/review/rules.json
+++ b/.github/review/rules.json
@@ -1,0 +1,683 @@
+{
+  "version": 1,
+  "updatedAt": "2026-08-07T00:00:00Z",
+  "defaults": {
+    "maxCommentsPerPR": 12,
+    "explorationPercent": 10
+  },
+  "rules": {
+    "SEC-001": {
+      "title": "Injection via unparameterised query",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-002": {
+      "title": "Missing authentication or authorisation on a new route",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-003": {
+      "title": "Secret, key, or credential committed",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-004": {
+      "title": "Unvalidated request input",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-005": {
+      "title": "Mass assignment",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-006": {
+      "title": "Unsafe rendering or DOM injection",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-007": {
+      "title": "Weak or hand-rolled cryptography",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-008": {
+      "title": "Overly permissive CORS or cookie flags",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "SEC-009": {
+      "title": "Dependency added with no obvious need",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "PHI-001": {
+      "title": "Patient-identifying data in logs",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "PHI-002": {
+      "title": "Patient data sent to a third party",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "PHI-003": {
+      "title": "Patient data in client-side storage",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "PHI-004": {
+      "title": "Over-broad response payload",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "PHI-005": {
+      "title": "Missing audit trail on a sensitive action",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-001": {
+      "title": "Destructive or irreversible migration",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-002": {
+      "title": "Multi-step write with no transaction",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-003": {
+      "title": "N+1 query",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-004": {
+      "title": "Unbounded query",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-005": {
+      "title": "New query pattern with no supporting index",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-006": {
+      "title": "Schema change without a corresponding migration",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "DATA-007": {
+      "title": "Connection or session not released",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "API-001": {
+      "title": "Breaking change to a published contract",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "API-002": {
+      "title": "Wrong or misleading status codes",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "API-003": {
+      "title": "Inconsistent response shape",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "API-004": {
+      "title": "Undocumented endpoint",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "ASYNC-001": {
+      "title": "Unhandled promise rejection path",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "ASYNC-002": {
+      "title": "Swallowed error",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "ASYNC-003": {
+      "title": "Awaiting in a loop where the work is independent",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "ASYNC-004": {
+      "title": "Race condition on shared state",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "ASYNC-005": {
+      "title": "External call with no timeout or retry policy",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "RT-001": {
+      "title": "Socket event handler without authentication",
+      "severity": "blocker",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "RT-002": {
+      "title": "Listener registered without cleanup",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "RT-003": {
+      "title": "Peer connection or media track not closed",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "RT-004": {
+      "title": "Broadcast to a room without an authorisation check",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "RT-005": {
+      "title": "No reconnection or degraded-network handling",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-001": {
+      "title": "Effect with a wrong or missing dependency array",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-002": {
+      "title": "State update after unmount",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-003": {
+      "title": "Subscription without teardown",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-004": {
+      "title": "Expensive work on every render",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-005": {
+      "title": "Unkeyed or index-keyed list",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-006": {
+      "title": "Accessibility gap on a new interactive element",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "FE-007": {
+      "title": "User-facing string hardcoded",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TS-001": {
+      "title": "`any` or a type assertion hiding a real mismatch",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TS-002": {
+      "title": "Missing null/undefined handling",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TS-003": {
+      "title": "`@ts-ignore` / `eslint-disable` with no justification",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TS-004": {
+      "title": "Dead or unreachable code",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TS-005": {
+      "title": "Duplicated logic",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TEST-001": {
+      "title": "Bug fix with no regression test",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TEST-002": {
+      "title": "New business logic with no test coverage",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TEST-003": {
+      "title": "Flaky test pattern",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "TEST-004": {
+      "title": "Assertion that cannot fail",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "OPS-001": {
+      "title": "Configuration hardcoded",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "OPS-002": {
+      "title": "New env var with no default, no validation, and no docs",
+      "severity": "major",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "OPS-003": {
+      "title": "Missing observability on a new critical path",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "OPS-004": {
+      "title": "Backwards-incompatible change with no deploy ordering\nnote",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "GEN-000": {
+      "title": "Issue not covered by an existing rule",
+      "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    }
+  },
+  "retired": {}
+}

--- a/.github/review/scripts/lib/github.mjs
+++ b/.github/review/scripts/lib/github.mjs
@@ -1,0 +1,169 @@
+/**
+ * Minimal GitHub REST + GraphQL client.
+ *
+ * Deliberately dependency-free: these scripts run in CI on every PR, and a
+ * zero-dependency script needs no `npm install` step, has no supply-chain
+ * surface, and cannot break because a transitive dependency shipped a bad
+ * release. Node 20+ has everything required.
+ */
+
+const API = process.env.GITHUB_API_URL || 'https://api.github.com';
+const GRAPHQL = process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
+
+function token() {
+  const t = process.env.GITHUB_TOKEN;
+  if (!t) throw new Error('GITHUB_TOKEN is not set');
+  return t;
+}
+
+function baseHeaders() {
+  return {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token()}`,
+    'x-github-api-version': '2022-11-28',
+    'user-agent': 'claude-pr-review-agent',
+  };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * REST request with retry on 5xx and secondary-rate-limit responses.
+ * @param {string} path e.g. `/repos/o/r/pulls/1/files`
+ * @param {{method?:string, body?:unknown, retries?:number}} [opts]
+ */
+export async function rest(path, opts = {}) {
+  const { method = 'GET', body, retries = 3 } = opts;
+  const url = path.startsWith('http') ? path : `${API}${path}`;
+
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const res = await fetch(url, {
+      method,
+      headers: {
+        ...baseHeaders(),
+        ...(body ? { 'content-type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (res.ok) {
+      const text = await res.text();
+      return {
+        data: text ? JSON.parse(text) : null,
+        link: res.headers.get('link') || '',
+      };
+    }
+
+    const text = await res.text();
+    const retryable =
+      res.status >= 500 ||
+      res.status === 429 ||
+      (res.status === 403 && /rate limit|abuse|secondary/i.test(text));
+
+    lastErr = new Error(`${method} ${url} -> ${res.status}: ${text.slice(0, 600)}`);
+    if (!retryable || attempt === retries) throw lastErr;
+
+    const retryAfter = Number(res.headers.get('retry-after'));
+    await sleep(Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 2 ** attempt * 1000);
+  }
+  throw lastErr;
+}
+
+/** Follow `Link: rel="next"` until exhausted. */
+export async function restAll(path, { max = 1000 } = {}) {
+  const out = [];
+  let url = path.includes('?') ? `${path}&per_page=100` : `${path}?per_page=100`;
+  while (url && out.length < max) {
+    const { data, link } = await rest(url);
+    if (!Array.isArray(data)) break;
+    out.push(...data);
+    const next = /<([^>]+)>;\s*rel="next"/.exec(link);
+    url = next ? next[1] : null;
+  }
+  return out.slice(0, max);
+}
+
+/** GraphQL request. Used only where REST has no equivalent (thread resolution). */
+export async function graphql(query, variables = {}) {
+  const res = await fetch(GRAPHQL, {
+    method: 'POST',
+    headers: { ...baseHeaders(), 'content-type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (!res.ok || json.errors) {
+    throw new Error(`GraphQL error: ${JSON.stringify(json.errors || json).slice(0, 600)}`);
+  }
+  return json.data;
+}
+
+/**
+ * Parse a unified diff patch into the set of new-file line numbers that GitHub
+ * will accept a RIGHT-side review comment on.
+ *
+ * This matters: posting a review with a single out-of-diff line makes the
+ * entire review request fail with a 422, losing every other comment with it.
+ * We check up front and demote anything out of range into the summary instead.
+ *
+ * @param {string} patch
+ * @returns {Set<number>}
+ */
+export function commentableLines(patch) {
+  const lines = new Set();
+  if (!patch) return lines;
+
+  let newLine = 0;
+  for (const raw of patch.split('\n')) {
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (raw.startsWith('\\')) continue; // "\ No newline at end of file"
+    if (raw.startsWith('-')) continue; // removed: exists only on the LEFT side
+    if (raw.startsWith('+') || raw.startsWith(' ')) {
+      lines.add(newLine);
+      newLine++;
+    }
+  }
+  return lines;
+}
+
+/** Files touched by a PR, with their patches. */
+export async function getPullFiles(repo, prNumber) {
+  return restAll(`/repos/${repo}/pulls/${prNumber}/files`, { max: 300 });
+}
+
+/** Existing review comments on a PR. */
+export async function getReviewComments(repo, prNumber) {
+  return restAll(`/repos/${repo}/pulls/${prNumber}/comments`, { max: 500 });
+}
+
+/** Reactions on a single PR review comment. */
+export async function getCommentReactions(repo, commentId) {
+  return restAll(`/repos/${repo}/pulls/comments/${commentId}/reactions`, { max: 100 });
+}
+
+/**
+ * Post one review containing all inline comments plus a summary body.
+ * @param {string} repo
+ * @param {number|string} prNumber
+ * @param {{commitId:string, body:string, event:'COMMENT'|'REQUEST_CHANGES', comments:Array<object>}} opts
+ */
+export async function createReview(repo, prNumber, { commitId, body, event, comments }) {
+  const { data } = await rest(`/repos/${repo}/pulls/${prNumber}/reviews`, {
+    method: 'POST',
+    body: { commit_id: commitId, body, event, comments },
+  });
+  return data;
+}
+
+/** Post a plain issue comment (used as the fallback when inline posting fails). */
+export async function createIssueComment(repo, prNumber, body) {
+  const { data } = await rest(`/repos/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    body: { body },
+  });
+  return data;
+}

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -1,0 +1,323 @@
+/**
+ * OpenRouter client for the review agent.
+ *
+ * Free models come with three constraints that shape everything here:
+ *
+ *   1. Most of them do not support structured outputs, so we cannot rely on a
+ *      JSON schema being enforced. We ask for JSON, then parse defensively.
+ *   2. The free lineup churns — models appear and disappear weekly. Hardcoding
+ *      IDs guarantees a workflow that breaks silently one morning, so we
+ *      discover what is currently free at runtime and fall back through a chain.
+ *   3. The daily request cap is low (50/day, or 1000 once you have bought $10
+ *      of credit). Requests are a budget to be spent, not a free resource, so
+ *      the diff is packed into as few calls as possible.
+ *
+ * Pure functions live here alongside the client so they can be unit tested
+ * without touching the network.
+ */
+
+const BASE = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+
+/** Rough token estimate. Deliberately pessimistic — overrunning context is worse. */
+export const CHARS_PER_TOKEN = 3.5;
+
+export function estimateTokens(text) {
+  return Math.ceil((text?.length || 0) / CHARS_PER_TOKEN);
+}
+
+/**
+ * Split a unified diff into per-file sections.
+ * @param {string} diff
+ * @returns {Array<{file:string, patch:string}>}
+ */
+export function splitDiffByFile(diff) {
+  if (!diff?.trim()) return [];
+  const out = [];
+  // Keep the `diff --git` header with its section.
+  const sections = diff.split(/(?=^diff --git )/m).filter((s) => s.trim());
+  for (const patch of sections) {
+    // `diff --git a/path b/path` — take the b-side, which is the new path.
+    const m = /^diff --git a\/(.+?) b\/(.+?)$/m.exec(patch);
+    out.push({ file: m ? m[2] : 'unknown', patch });
+  }
+  return out;
+}
+
+/**
+ * Pack per-file diffs into as few requests as possible without blowing the
+ * context window.
+ *
+ * A file whose own diff exceeds the budget is truncated rather than dropped —
+ * a partial review of a big file beats no review at all, and the truncation is
+ * marked inline so the model knows not to reason about what it cannot see.
+ *
+ * @param {Array<{file:string, patch:string}>} files
+ * @param {{budgetChars:number, maxChunks:number}} opts
+ * @returns {{chunks:Array<Array<{file:string,patch:string}>>, skipped:string[], truncated:string[]}}
+ */
+export function packChunks(files, { budgetChars, maxChunks }) {
+  const chunks = [];
+  const skipped = [];
+  const truncated = [];
+  let current = [];
+  let currentSize = 0;
+
+  // Smallest first, so one enormous file cannot starve everything behind it.
+  const ordered = [...files].sort((a, b) => a.patch.length - b.patch.length);
+
+  for (const f of ordered) {
+    let patch = f.patch;
+    if (patch.length > budgetChars) {
+      patch = patch.slice(0, budgetChars) + '\n... [diff truncated for length] ...\n';
+      truncated.push(f.file);
+    }
+    if (currentSize + patch.length > budgetChars && current.length) {
+      chunks.push(current);
+      current = [];
+      currentSize = 0;
+    }
+    current.push({ file: f.file, patch });
+    currentSize += patch.length;
+  }
+  if (current.length) chunks.push(current);
+
+  if (chunks.length > maxChunks) {
+    for (const chunk of chunks.slice(maxChunks)) skipped.push(...chunk.map((f) => f.file));
+    return { chunks: chunks.slice(0, maxChunks), skipped, truncated };
+  }
+  return { chunks, skipped, truncated };
+}
+
+/**
+ * Recover a JSON object from whatever a free model actually returned.
+ *
+ * Free models routinely wrap JSON in markdown fences, prefix it with "Here is
+ * the review:", or emit <think> blocks first. Without this, roughly a third of
+ * responses would be thrown away.
+ *
+ * @param {string} text
+ * @returns {object|null}
+ */
+export function extractJson(text) {
+  if (typeof text !== 'string' || !text.trim()) return null;
+
+  // Reasoning models emit their scratchpad first.
+  let s = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
+
+  const attempt = (candidate) => {
+    try {
+      const parsed = JSON.parse(candidate);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  };
+
+  let parsed = attempt(s);
+  if (parsed) return parsed;
+
+  // ```json ... ``` fences
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(s);
+  if (fenced) {
+    parsed = attempt(fenced[1].trim());
+    if (parsed) return parsed;
+    s = fenced[1];
+  }
+
+  // Scan for the first balanced object, respecting strings and escapes.
+  const start = s.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < s.length; i++) {
+    const c = s[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (c === '"') inString = !inString;
+    if (inString) continue;
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return attempt(s.slice(start, i + 1));
+    }
+  }
+  return null;
+}
+
+/**
+ * Compact one-line-per-rule digest for the prompt.
+ *
+ * The full rulebook is ~14 KB of prose. Sending it on every request would eat
+ * the context budget a free model needs for the actual diff, so the model gets
+ * IDs, severities and titles, and the prose stays as documentation for humans.
+ *
+ * Muted rules are omitted entirely — that is how the feedback loop's mute
+ * decision reaches the model. On an exploration slot a muted rule is put back,
+ * so it can still earn its way out of the mute.
+ *
+ * @param {Record<string, {title:string, severity:string, state:string}>} rules
+ * @param {(ruleId:string)=>boolean} isExploring
+ * @returns {{digest:string, included:string[], exploring:string[]}}
+ */
+export function buildRulesDigest(rules, isExploring = () => false) {
+  const lines = [];
+  const included = [];
+  const exploring = [];
+
+  for (const [id, rule] of Object.entries(rules)) {
+    if (rule.state === 'muted') {
+      if (!isExploring(id)) continue;
+      exploring.push(id);
+    }
+    const note =
+      rule.state === 'probation' ? ' (only report at blocker/major severity)' : '';
+    lines.push(`${id} [${rule.severity}] ${rule.title}${note}`);
+    included.push(id);
+  }
+
+  return { digest: lines.join('\n'), included, exploring };
+}
+
+/**
+ * Fetch the models that are currently free, largest context first.
+ * @param {string} apiKey
+ * @returns {Promise<Array<{id:string, context:number, structured:boolean}>>}
+ */
+export async function listFreeModels(apiKey) {
+  const res = await fetch(`${BASE}/models`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) throw new Error(`GET /models -> ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const { data } = await res.json();
+
+  return (data || [])
+    .filter((m) => typeof m.id === 'string' && m.id.endsWith(':free'))
+    .map((m) => ({
+      id: m.id,
+      context: Number(m.context_length) || 0,
+      structured: (m.supported_parameters || []).includes('structured_outputs'),
+    }))
+    .sort((a, b) => b.context - a.context);
+}
+
+/**
+ * Choose the model chain to send.
+ *
+ * `preferred` wins where those models are actually available today; anything
+ * still free is appended as a fallback so a retired model degrades into a
+ * slightly worse review rather than a red workflow.
+ *
+ * @param {Array<{id:string, context:number, structured:boolean}>} available
+ * @param {string[]} preferred
+ * @param {number} limit
+ */
+export function chooseModels(available, preferred = [], limit = 4) {
+  const byId = new Map(available.map((m) => [m.id, m]));
+  const chain = [];
+  for (const id of preferred) {
+    if (byId.has(id)) chain.push(byId.get(id));
+  }
+  for (const m of available) {
+    if (chain.length >= limit) break;
+    if (!chain.some((c) => c.id === m.id)) chain.push(m);
+  }
+  return chain.slice(0, limit);
+}
+
+/**
+ * One chat completion, with OpenRouter's built-in fallback chain.
+ *
+ * OpenRouter falls back through `models` on rate limits, downtime, context
+ * errors and moderation, which covers exactly the failure modes free models
+ * hit. Retries here are only for transport-level problems.
+ *
+ * @param {{apiKey:string, models:string[], system:string, user:string,
+ *          maxTokens?:number, jsonMode?:boolean, retries?:number,
+ *          referer?:string, title?:string}} opts
+ * @returns {Promise<{text:string, model:string, usage:object|null}>}
+ */
+export async function complete(opts) {
+  const {
+    apiKey,
+    models,
+    system,
+    user,
+    maxTokens = 4000,
+    jsonMode = false,
+    retries = 2,
+    referer = 'https://github.com',
+    title = 'PR Review Agent',
+  } = opts;
+
+  const body = {
+    model: models[0],
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: user },
+    ],
+    temperature: 0.1,
+    max_tokens: maxTokens,
+  };
+  if (models.length > 1) body.models = models;
+  if (jsonMode) body.response_format = { type: 'json_object' };
+
+  let lastErr;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(`${BASE}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+          // OpenRouter uses these for attribution on its dashboard.
+          'http-referer': referer,
+          'x-title': title,
+        },
+        body: JSON.stringify(body),
+      });
+
+      const text = await res.text();
+      if (!res.ok) {
+        const retryable = res.status === 429 || res.status >= 500;
+        lastErr = new Error(`POST /chat/completions -> ${res.status}: ${text.slice(0, 400)}`);
+        if (!retryable || attempt === retries) throw lastErr;
+        const wait = Number(res.headers.get('retry-after')) * 1000 || 2 ** attempt * 4000;
+        await new Promise((r) => setTimeout(r, wait));
+        continue;
+      }
+
+      const json = JSON.parse(text);
+      // OpenRouter can return a 200 whose body carries a provider error.
+      if (json.error) throw new Error(`provider error: ${JSON.stringify(json.error).slice(0, 300)}`);
+      return {
+        text: json.choices?.[0]?.message?.content ?? '',
+        model: json.model || models[0],
+        usage: json.usage || null,
+      };
+    } catch (err) {
+      lastErr = err;
+      if (attempt === retries) throw lastErr;
+      await new Promise((r) => setTimeout(r, 2 ** attempt * 2000));
+    }
+  }
+  throw lastErr;
+}
+
+/** Remaining free-tier allowance, for logging. Never throws. */
+export async function keyStatus(apiKey) {
+  try {
+    const res = await fetch(`${BASE}/key`, { headers: { authorization: `Bearer ${apiKey}` } });
+    if (!res.ok) return null;
+    const { data } = await res.json();
+    return data || null;
+  } catch {
+    return null;
+  }
+}

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -208,6 +208,12 @@ export async function listFreeModels(apiKey) {
 }
 
 /**
+ * OpenRouter rejects a `models` fallback array longer than this with a 400.
+ * Every chain that reaches the API is clamped to it.
+ */
+export const MAX_FALLBACK_MODELS = 3;
+
+/**
  * Choose the model chain to send.
  *
  * `preferred` wins where those models are actually available today; anything
@@ -218,7 +224,7 @@ export async function listFreeModels(apiKey) {
  * @param {string[]} preferred
  * @param {number} limit
  */
-export function chooseModels(available, preferred = [], limit = 4) {
+export function chooseModels(available, preferred = [], limit = MAX_FALLBACK_MODELS) {
   const byId = new Map(available.map((m) => [m.id, m]));
   const chain = [];
   for (const id of preferred) {
@@ -256,8 +262,10 @@ export async function complete(opts) {
     title = 'PR Review Agent',
   } = opts;
 
+  const chain = models.slice(0, MAX_FALLBACK_MODELS);
+
   const body = {
-    model: models[0],
+    model: chain[0],
     messages: [
       { role: 'system', content: system },
       { role: 'user', content: user },
@@ -265,7 +273,7 @@ export async function complete(opts) {
     temperature: 0.1,
     max_tokens: maxTokens,
   };
-  if (models.length > 1) body.models = models;
+  if (chain.length > 1) body.models = chain;
   if (jsonMode) body.response_format = { type: 'json_object' };
 
   let lastErr;
@@ -298,7 +306,7 @@ export async function complete(opts) {
       if (json.error) throw new Error(`provider error: ${JSON.stringify(json.error).slice(0, 300)}`);
       return {
         text: json.choices?.[0]?.message?.content ?? '',
-        model: json.model || models[0],
+        model: json.model || chain[0],
         usage: json.usage || null,
       };
     } catch (err) {

--- a/.github/review/scripts/lib/scoring.mjs
+++ b/.github/review/scripts/lib/scoring.mjs
@@ -1,0 +1,283 @@
+/**
+ * Pure scoring logic for the review agent's feedback loop.
+ *
+ * No I/O, no network, no clock reads — everything here is a pure function of
+ * its inputs so it can be unit tested and so two runs over the same PR always
+ * make the same decisions.
+ *
+ * The model is a Beta-Bernoulli posterior per rule. Each rule starts with a
+ * prior worth three observations centred on 0.7 (we assume a hand-written rule
+ * is probably useful, but we do not assume it strongly). Every human reaction
+ * to a comment the rule produced updates that posterior. The posterior mean is
+ * the rule's weight, and the weight gates whether future findings get posted.
+ */
+
+/** Prior: alpha/(alpha+beta) = 0.7, total strength 3 observations. */
+export const PRIOR_ALPHA = 2.1;
+export const PRIOR_BETA = 0.9;
+
+/** An ignored comment is weak evidence against a rule, not proof. */
+export const IGNORED_WEIGHT = 0.4;
+
+/** Minimum effective score (confidence x weight) required to post a finding. */
+export const SEVERITY_GATES = {
+  blocker: 0.3,
+  major: 0.36,
+  minor: 0.42,
+  nit: 0.5,
+};
+
+export const SEVERITY_ORDER = { blocker: 0, major: 1, minor: 2, nit: 3 };
+
+/** State transition thresholds. */
+export const MUTE_WEIGHT = 0.3;
+export const MUTE_MIN_EVIDENCE = 8;
+export const PROBATION_WEIGHT = 0.5;
+export const PROBATION_MIN_EVIDENCE = 5;
+
+/**
+ * @typedef {{accepted:number, rejected:number, ignored:number}} RuleStats
+ * @typedef {{title:string, severity:string, weight:number, state:string,
+ *            stats:RuleStats, history?:Array<object>}} Rule
+ * @typedef {{ruleId:string, file:string, line:number, endLine?:number,
+ *            severity:string, confidence:number, title:string, body:string,
+ *            suggestion?:string}} Finding
+ */
+
+/**
+ * Posterior mean of the rule's usefulness, in [0,1].
+ * @param {RuleStats} stats
+ * @returns {number}
+ */
+export function computeWeight(stats) {
+  const accepted = Math.max(0, stats.accepted || 0);
+  const rejected = Math.max(0, stats.rejected || 0);
+  const ignored = Math.max(0, stats.ignored || 0);
+  const alpha = PRIOR_ALPHA + accepted;
+  const beta = PRIOR_BETA + rejected + ignored * IGNORED_WEIGHT;
+  return round3(alpha / (alpha + beta));
+}
+
+/** Total human observations backing a rule. */
+export function evidenceCount(stats) {
+  return (stats.accepted || 0) + (stats.rejected || 0) + (stats.ignored || 0);
+}
+
+/**
+ * Decide a rule's state from its weight and how much evidence backs it.
+ * A rule is never muted on thin evidence — that is the whole point of
+ * requiring a minimum observation count before demoting it.
+ * @param {number} weight
+ * @param {number} n
+ * @returns {'active'|'probation'|'muted'}
+ */
+export function computeState(weight, n) {
+  if (n >= MUTE_MIN_EVIDENCE && weight < MUTE_WEIGHT) return 'muted';
+  if (n >= PROBATION_MIN_EVIDENCE && weight < PROBATION_WEIGHT) return 'probation';
+  return 'active';
+}
+
+/**
+ * Deterministic 32-bit hash. Used for exploration slots so that re-running the
+ * workflow on the same PR makes the same choice — no Math.random anywhere.
+ * @param {string} str
+ * @returns {number}
+ */
+export function hash32(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/**
+ * Epsilon-greedy exploration: a muted rule is occasionally allowed to speak
+ * again so it can earn its way back. Without this, a rule muted by a run of bad
+ * luck stays muted forever and the loop can never correct itself.
+ * @param {string} ruleId
+ * @param {number|string} prNumber
+ * @param {number} percent 0-100
+ * @returns {boolean}
+ */
+export function isExplorationSlot(ruleId, prNumber, percent) {
+  if (!percent || percent <= 0) return false;
+  return hash32(`${ruleId}#${prNumber}`) % 100 < percent;
+}
+
+/**
+ * Stable identifier for a finding, so re-runs on `synchronize` do not repost
+ * the same comment. Deliberately excludes confidence and body text: the same
+ * issue on the same line is the same issue even if the wording shifts.
+ * @param {Finding} f
+ * @returns {string}
+ */
+export function findingId(f) {
+  return hash32(`${f.ruleId}|${f.file}|${f.line}|${f.severity}`)
+    .toString(36)
+    .padStart(7, '0');
+}
+
+/**
+ * Gate findings against the learned rule weights.
+ *
+ * @param {Finding[]} findings
+ * @param {Record<string, Rule>} rules
+ * @param {{prNumber:number|string, maxComments:number, explorationPercent:number,
+ *          alreadyPosted?:Set<string>}} opts
+ * @returns {{kept:Finding[], dropped:Array<{finding:Finding, reason:string}>}}
+ */
+export function gateFindings(findings, rules, opts) {
+  const {
+    prNumber,
+    maxComments = 12,
+    explorationPercent = 10,
+    alreadyPosted = new Set(),
+  } = opts;
+
+  const kept = [];
+  const dropped = [];
+
+  for (const f of findings) {
+    const rule = rules[f.ruleId];
+    if (!rule) {
+      dropped.push({ finding: f, reason: `unknown rule id ${f.ruleId}` });
+      continue;
+    }
+
+    const fid = findingId(f);
+    if (alreadyPosted.has(fid)) {
+      dropped.push({ finding: f, reason: 'already posted on an earlier run' });
+      continue;
+    }
+
+    let exploring = false;
+    if (rule.state === 'muted') {
+      if (isExplorationSlot(f.ruleId, prNumber, explorationPercent)) {
+        exploring = true;
+      } else {
+        dropped.push({ finding: f, reason: 'rule muted by feedback loop' });
+        continue;
+      }
+    }
+
+    if (rule.state === 'probation' && SEVERITY_ORDER[f.severity] > SEVERITY_ORDER.major) {
+      dropped.push({ finding: f, reason: 'rule on probation; only blocker/major posted' });
+      continue;
+    }
+
+    const confidence = clamp01(f.confidence);
+    const score = round3(confidence * rule.weight);
+    const gate = SEVERITY_GATES[f.severity] ?? SEVERITY_GATES.minor;
+    // Exploration deliberately bypasses the score gate. A muted rule's weight
+    // is by definition too low to clear it, so leaving the gate in place here
+    // would mean muted rules could never gather the evidence they need to
+    // recover — the exploration slot would be dead code.
+    if (!exploring && score < gate) {
+      dropped.push({
+        finding: f,
+        reason: `score ${score} below ${f.severity} gate ${gate}`,
+      });
+      continue;
+    }
+
+    kept.push({ ...f, _fid: fid, _score: score, _exploring: exploring });
+  }
+
+  // Most severe first, then most confident. Cap so one noisy PR cannot bury
+  // the author in comments.
+  kept.sort(
+    (a, b) =>
+      (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9) ||
+      b._score - a._score,
+  );
+
+  const overflow = kept.slice(maxComments);
+  for (const f of overflow) {
+    dropped.push({ finding: f, reason: `over the ${maxComments}-comment cap` });
+  }
+
+  return { kept: kept.slice(0, maxComments), dropped };
+}
+
+/** Half-life, in days, for how fast an old outcome stops counting. */
+export const DECAY_HALF_LIFE_DAYS = 90;
+
+/**
+ * How much a single outcome still counts, given its age.
+ *
+ * Feedback decays so the rulebook tracks how a rule behaves *now*. Without it,
+ * a rule that was noisy last year could never recover after its wording was
+ * improved, and the loop would only ever ratchet in one direction.
+ *
+ * @param {string} outcomeAt ISO timestamp of the outcome
+ * @param {string} now ISO timestamp of this run
+ * @returns {number} decay factor in (0,1]
+ */
+export function decayFactor(outcomeAt, now) {
+  const ageMs = Date.parse(now) - Date.parse(outcomeAt);
+  if (!Number.isFinite(ageMs) || ageMs <= 0) return 1;
+  const ageDays = ageMs / 86_400_000;
+  return round3(Math.pow(0.5, ageDays / DECAY_HALF_LIFE_DAYS));
+}
+
+/**
+ * Rebuild every rule's stats, weight, and state from the full outcome ledger.
+ *
+ * This is a full recompute rather than an incremental update, deliberately: the
+ * ledger is the single source of truth, so re-running the tuning job is
+ * idempotent, a mis-scored outcome can be corrected by editing the ledger, and
+ * the decay above is applied consistently to every observation on every run.
+ *
+ * @param {Record<string, Rule>} rules current rulebook (stats are ignored)
+ * @param {Array<{ruleId:string, outcome:'accepted'|'rejected'|'ignored', at:string}>} outcomes
+ * @param {string} now ISO timestamp of this run
+ * @returns {{rules:Record<string,Rule>, changes:Array<object>}}
+ */
+export function rebuildRules(rules, outcomes, now) {
+  const next = structuredClone(rules);
+  for (const rule of Object.values(next)) {
+    rule.stats = { accepted: 0, rejected: 0, ignored: 0 };
+  }
+
+  for (const o of outcomes) {
+    const rule = next[o.ruleId];
+    if (!rule) continue;
+    const bucket =
+      o.outcome === 'accepted' ? 'accepted' : o.outcome === 'rejected' ? 'rejected' : 'ignored';
+    rule.stats[bucket] += decayFactor(o.at, now);
+  }
+
+  const changes = [];
+  for (const [ruleId, rule] of Object.entries(next)) {
+    for (const k of ['accepted', 'rejected', 'ignored']) rule.stats[k] = round3(rule.stats[k]);
+
+    const before = { weight: rules[ruleId].weight, state: rules[ruleId].state };
+    rule.weight = computeWeight(rule.stats);
+    rule.state = computeState(rule.weight, evidenceCount(rule.stats));
+
+    if (before.weight !== rule.weight || before.state !== rule.state) {
+      const entry = {
+        at: now,
+        stats: { ...rule.stats },
+        weight: [before.weight, rule.weight],
+        state: [before.state, rule.state],
+      };
+      rule.history = [...(rule.history || []), entry].slice(-20);
+      changes.push({ ruleId, title: rule.title, ...entry });
+    }
+  }
+
+  return { rules: next, changes };
+}
+
+export function clamp01(n) {
+  const v = Number(n);
+  if (!Number.isFinite(v)) return 0;
+  return Math.min(1, Math.max(0, v));
+}
+
+export function round3(n) {
+  return Math.round(n * 1000) / 1000;
+}

--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * Produces .claude-review/findings.json using OpenRouter's free models.
+ *
+ * Drop-in replacement for the Claude Code Action step. It writes the same file
+ * in the same schema, so post-review.mjs, the rule gating and the whole
+ * feedback loop carry on unchanged — only the thing generating the findings
+ * changes.
+ *
+ * The trade versus an agentic reviewer is real and worth stating: this sends
+ * the diff and gets findings back in one shot per chunk. It cannot go and read
+ * the surrounding file, grep for the caller, or check whether a guard exists
+ * elsewhere. Expect more misses on anything that needs repo context, and lean
+ * on the confidence gates to keep the noise down.
+ *
+ * Never exits non-zero. A failed review must not fail anyone's build.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  buildRulesDigest,
+  chooseModels,
+  complete,
+  estimateTokens,
+  extractJson,
+  keyStatus,
+  listFreeModels,
+  packChunks,
+  splitDiffByFile,
+  CHARS_PER_TOKEN,
+} from './lib/openrouter.mjs';
+import { isExplorationSlot } from './lib/scoring.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_PATH = join(HERE, '..', 'rules.json');
+const OUT_DIR = '.claude-review';
+const DIFF_PATH = join(OUT_DIR, 'pr.diff');
+const FINDINGS_PATH = join(OUT_DIR, 'findings.json');
+const DEBUG_PATH = join(OUT_DIR, 'openrouter-debug.json');
+
+const API_KEY = process.env.OPENROUTER_API_KEY;
+const PR_NUMBER = process.env.PR_NUMBER || '0';
+const PR_TITLE = process.env.PR_TITLE || '';
+const PR_BODY = (process.env.PR_BODY || '').slice(0, 1500);
+const MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 4;
+const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 4000;
+const PREFERRED = (process.env.OPENROUTER_MODELS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+/** Free tier allows 20 requests/minute. Stay comfortably under it. */
+const REQUEST_SPACING_MS = 3500;
+
+/**
+ * Even on a 262k-context model, quality falls off long before the window does.
+ * Capping the chunk keeps a weak model focused on a reviewable amount of code.
+ */
+const MAX_CHUNK_CHARS = 40_000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const SYSTEM_PROMPT = `You are a precise code reviewer. You review only the changed lines in a git diff.
+
+You reply with a single JSON object and nothing else. No prose before it, no prose after it, no markdown code fences.
+
+You are strict about false positives. A short review with two real problems is far more valuable than a long one with ten guesses. If you are not confident something is a genuine defect, leave it out.
+
+Never report: formatting or style that a linter handles, naming preferences, missing comments, speculative refactors, praise, or restatements of what the code does.`;
+
+function userPrompt({ digest, chunk, chunkIndex, chunkCount }) {
+  const files = chunk.map((f) => f.file).join('\n');
+  const diff = chunk.map((f) => f.patch).join('\n');
+
+  return `Review this pull request diff against the rules below.
+
+${PR_TITLE ? `PULL REQUEST TITLE\n${PR_TITLE}\n` : ''}${PR_BODY ? `\nDESCRIPTION\n${PR_BODY}\n` : ''}
+RULES — every finding must cite one of these rule IDs. If you find a real problem that no rule covers, use GEN-000 and name the missing rule in the body.
+
+${digest}
+
+FILES IN THIS BATCH${chunkCount > 1 ? ` (batch ${chunkIndex + 1} of ${chunkCount})` : ''}
+${files}
+
+DIFF
+${diff}
+
+Report only problems in lines this diff ADDS or MODIFIES. Lines starting with "+" are added; lines starting with " " are unchanged context shown for reference only — do not report issues in them.
+
+You are seeing only the diff, not the whole repository. If judging something would require code you cannot see, either lower your confidence accordingly or leave it out.
+
+Reply with exactly this JSON shape:
+
+{
+  "summary": "2-3 sentences on this batch of changes",
+  "findings": [
+    {
+      "ruleId": "SEC-001",
+      "file": "exact path from the FILES list above",
+      "line": 42,
+      "endLine": 42,
+      "severity": "blocker | major | minor | nit",
+      "confidence": 0.85,
+      "title": "one line, under 80 characters",
+      "body": "why this is a problem here and what to do about it",
+      "suggestion": "optional: exact replacement code for those lines, no code fences"
+    }
+  ]
+}
+
+"line" must be the line number in the NEW version of the file, counted from the diff hunk headers (@@ -old,n +new,n @@). Count carefully: added and context lines advance the new-file counter, removed lines do not.
+
+"confidence" is your honest probability from 0 to 1 that an experienced engineer on this codebase would agree this is a real problem. Anything below 0.6 should not be reported at all.
+
+If you find nothing worth reporting, return an empty findings array. That is a perfectly good answer.`;
+}
+
+/** Keep only findings that name a file we actually sent and a rule that exists. */
+function sanitise(findings, chunkFiles, validRuleIds) {
+  const fileSet = new Set(chunkFiles);
+  const out = [];
+  const rejected = [];
+
+  for (const f of Array.isArray(findings) ? findings : []) {
+    if (!f || typeof f !== 'object') continue;
+
+    const ruleId = String(f.ruleId || '').toUpperCase().trim();
+    const line = Number.parseInt(f.line, 10);
+    const endLine = Number.parseInt(f.endLine, 10);
+    const severity = String(f.severity || '').toLowerCase().trim();
+    const confidence = Number(f.confidence);
+
+    if (!validRuleIds.has(ruleId)) {
+      rejected.push(`invented rule id ${f.ruleId}`);
+      continue;
+    }
+    if (!fileSet.has(f.file)) {
+      rejected.push(`file not in this batch: ${f.file}`);
+      continue;
+    }
+    if (!Number.isInteger(line) || line < 1) {
+      rejected.push(`bad line on ${ruleId}`);
+      continue;
+    }
+    if (!['blocker', 'major', 'minor', 'nit'].includes(severity)) {
+      rejected.push(`bad severity on ${ruleId}`);
+      continue;
+    }
+    if (!Number.isFinite(confidence) || confidence < 0.6) {
+      rejected.push(`confidence below threshold on ${ruleId}`);
+      continue;
+    }
+    if (!f.title || !f.body) {
+      rejected.push(`missing title or body on ${ruleId}`);
+      continue;
+    }
+
+    out.push({
+      ruleId,
+      file: f.file,
+      line,
+      ...(Number.isInteger(endLine) && endLine >= line ? { endLine } : {}),
+      severity,
+      confidence: Math.min(1, Math.max(0, confidence)),
+      title: String(f.title).slice(0, 120),
+      body: String(f.body).slice(0, 4000),
+      ...(f.suggestion ? { suggestion: String(f.suggestion).slice(0, 2000) } : {}),
+    });
+  }
+  return { findings: out, rejected };
+}
+
+function writeFindings(payload) {
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(FINDINGS_PATH, JSON.stringify(payload, null, 2));
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  if (!API_KEY) {
+    console.error('OPENROUTER_API_KEY is not set.');
+    writeFindings({ summary: 'Review skipped: no OpenRouter API key configured.', findings: [] });
+    return;
+  }
+  if (!existsSync(DIFF_PATH)) {
+    console.error(`${DIFF_PATH} is missing.`);
+    writeFindings({ summary: 'Review skipped: no diff was produced.', findings: [] });
+    return;
+  }
+
+  const diff = readFileSync(DIFF_PATH, 'utf8');
+  if (!diff.trim()) {
+    writeFindings({ summary: 'No reviewable changes in this pull request.', findings: [] });
+    return;
+  }
+
+  const book = JSON.parse(readFileSync(RULES_PATH, 'utf8'));
+  const explorationPercent = book.defaults?.explorationPercent ?? 10;
+  const { digest, included, exploring } = buildRulesDigest(book.rules, (ruleId) =>
+    isExplorationSlot(ruleId, PR_NUMBER, explorationPercent),
+  );
+  const validRuleIds = new Set(included);
+  console.log(
+    `Rulebook v${book.version}: ${included.length} rule(s) in play` +
+      (exploring.length ? `, re-testing muted ${exploring.join(', ')}` : ''),
+  );
+
+  // --- pick models --------------------------------------------------------
+  let available;
+  try {
+    available = await listFreeModels(API_KEY);
+  } catch (err) {
+    console.error(`Could not list models: ${err.message}`);
+    writeFindings({ summary: `Review skipped: OpenRouter unreachable (${err.message}).`, findings: [] });
+    return;
+  }
+  if (available.length === 0) {
+    writeFindings({ summary: 'Review skipped: no free models are currently available.', findings: [] });
+    return;
+  }
+
+  const chain = chooseModels(available, PREFERRED, 4);
+  const minContext = Math.min(...chain.map((m) => m.context));
+  const jsonMode = chain.every((m) => m.structured);
+  console.log(`Model chain: ${chain.map((m) => m.id).join(' -> ')}`);
+  console.log(`Smallest context in chain: ${minContext} tokens. JSON mode: ${jsonMode}.`);
+
+  const status = await keyStatus(API_KEY);
+  if (status) {
+    console.log(
+      `Key usage: ${status.usage ?? '?'} / limit ${status.limit ?? 'none'}` +
+        (status.rate_limit ? ` (${status.rate_limit.requests}/${status.rate_limit.interval})` : ''),
+    );
+  }
+
+  // --- chunk the diff -----------------------------------------------------
+  const overheadTokens = estimateTokens(SYSTEM_PROMPT + digest) + 800;
+  const budgetTokens = Math.max(2000, minContext - MAX_OUTPUT_TOKENS - overheadTokens);
+  const budgetChars = Math.min(MAX_CHUNK_CHARS, Math.floor(budgetTokens * CHARS_PER_TOKEN));
+
+  const files = splitDiffByFile(diff);
+  const { chunks, skipped, truncated } = packChunks(files, { budgetChars, maxChunks: MAX_REQUESTS });
+  console.log(
+    `${files.length} file(s) -> ${chunks.length} request(s) at ${budgetChars} chars each.` +
+      (truncated.length ? ` Truncated: ${truncated.join(', ')}.` : '') +
+      (skipped.length ? ` Skipped (request cap): ${skipped.join(', ')}.` : ''),
+  );
+
+  // --- review -------------------------------------------------------------
+  const all = [];
+  const summaries = [];
+  const debug = [];
+  const seen = new Set();
+  let failures = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const chunkFiles = chunk.map((f) => f.file);
+    if (i > 0) await sleep(REQUEST_SPACING_MS);
+
+    let result;
+    try {
+      result = await complete({
+        apiKey: API_KEY,
+        models: chain.map((m) => m.id),
+        system: SYSTEM_PROMPT,
+        user: userPrompt({ digest, chunk, chunkIndex: i, chunkCount: chunks.length }),
+        maxTokens: MAX_OUTPUT_TOKENS,
+        jsonMode,
+        title: `PR Review #${PR_NUMBER}`,
+      });
+    } catch (err) {
+      console.error(`Batch ${i + 1} failed: ${err.message}`);
+      debug.push({ batch: i + 1, files: chunkFiles, error: err.message });
+      failures++;
+      continue;
+    }
+
+    let parsed = extractJson(result.text);
+
+    // Free models sometimes narrate before the JSON. One cheap repair attempt.
+    if (!parsed) {
+      console.log(`Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`);
+      await sleep(REQUEST_SPACING_MS);
+      try {
+        const repair = await complete({
+          apiKey: API_KEY,
+          models: chain.map((m) => m.id),
+          system: SYSTEM_PROMPT,
+          user:
+            'Your previous reply was not valid JSON. Return the same content as a single JSON ' +
+            'object with keys "summary" and "findings", and nothing else.\n\n' +
+            'Previous reply:\n' +
+            result.text.slice(0, 6000),
+          maxTokens: MAX_OUTPUT_TOKENS,
+          jsonMode,
+        });
+        parsed = extractJson(repair.text);
+      } catch (err) {
+        console.error(`Batch ${i + 1} repair failed: ${err.message}`);
+      }
+    }
+
+    if (!parsed) {
+      debug.push({ batch: i + 1, files: chunkFiles, model: result.model, unparseable: result.text.slice(0, 1200) });
+      failures++;
+      continue;
+    }
+
+    const { findings, rejected } = sanitise(parsed.findings, chunkFiles, validRuleIds);
+    for (const f of findings) {
+      const key = `${f.ruleId}|${f.file}|${f.line}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      all.push(f);
+    }
+    if (parsed.summary) summaries.push(String(parsed.summary).trim());
+
+    console.log(
+      `Batch ${i + 1}/${chunks.length} via ${result.model}: ` +
+        `${findings.length} finding(s) kept, ${rejected.length} rejected.`,
+    );
+    debug.push({
+      batch: i + 1,
+      files: chunkFiles,
+      model: result.model,
+      usage: result.usage,
+      kept: findings.length,
+      rejected,
+    });
+  }
+
+  // --- assemble -----------------------------------------------------------
+  const notes = [];
+  if (truncated.length) notes.push(`Large diffs truncated in: ${truncated.join(', ')}.`);
+  if (skipped.length) {
+    notes.push(`Not reviewed — hit the ${MAX_REQUESTS}-request budget: ${skipped.join(', ')}.`);
+  }
+  if (failures) notes.push(`${failures} of ${chunks.length} batch(es) failed and were skipped.`);
+
+  const summary =
+    [summaries.join(' '), notes.join(' ')].filter(Boolean).join('\n\n') ||
+    'No reviewable findings were produced.';
+
+  writeFindings({ summary, findings: all });
+  writeFileSync(DEBUG_PATH, JSON.stringify({ chain: chain.map((m) => m.id), debug }, null, 2));
+  console.log(`Wrote ${all.length} finding(s) to ${FINDINGS_PATH}.`);
+}
+
+main().catch((err) => {
+  console.error(`openrouter-review failed: ${err.stack || err.message}`);
+  try {
+    writeFindings({ summary: `Review failed: ${err.message}`, findings: [] });
+  } catch {
+    /* nothing more we can do */
+  }
+});

--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -27,6 +27,7 @@ import {
   extractJson,
   keyStatus,
   listFreeModels,
+  MAX_FALLBACK_MODELS,
   packChunks,
   splitDiffByFile,
   CHARS_PER_TOKEN,
@@ -222,7 +223,7 @@ async function main() {
     return;
   }
 
-  const chain = chooseModels(available, PREFERRED, 4);
+  const chain = chooseModels(available, PREFERRED, MAX_FALLBACK_MODELS);
   const minContext = Math.min(...chain.map((m) => m.context));
   const jsonMode = chain.every((m) => m.structured);
   console.log(`Model chain: ${chain.map((m) => m.id).join(' -> ')}`);
@@ -339,7 +340,15 @@ async function main() {
   if (skipped.length) {
     notes.push(`Not reviewed — hit the ${MAX_REQUESTS}-request budget: ${skipped.join(', ')}.`);
   }
-  if (failures) notes.push(`${failures} of ${chunks.length} batch(es) failed and were skipped.`);
+  if (failures === chunks.length) {
+    notes.push(
+      `**Nothing was reviewed.** All ${chunks.length} batch(es) failed, so an absence of ` +
+        `findings below means the diff was never read — not that it is clean. ` +
+        `See the workflow log for the provider error.`,
+    );
+  } else if (failures) {
+    notes.push(`${failures} of ${chunks.length} batch(es) failed and were skipped.`);
+  }
 
   const summary =
     [summaries.join(' '), notes.join(' ')].filter(Boolean).join('\n\n') ||

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -96,7 +96,11 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
   lines.push(summary || '_No summary was produced._', '');
 
   if (kept.length === 0) {
-    lines.push('No findings above the confidence threshold. Nothing to flag.');
+    // A clean verdict is only honest when something was actually read. The
+    // generator says so in the summary when it reviewed nothing at all.
+    if (!/nothing was reviewed/i.test(summary || '')) {
+      lines.push('No findings above the confidence threshold. Nothing to flag.');
+    }
   } else {
     lines.push(
       'Findings: ' +

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Reads the findings Claude produced, gates them against the learned rule
+ * weights, and posts a single PR review.
+ *
+ * Why this is a separate step and not something the model does itself:
+ *   - every posted comment carries a machine-readable marker, so the tuning
+ *     job can attribute human feedback back to a specific rule and finding;
+ *   - the comment cap, the confidence gates and the mute list are enforced
+ *     deterministically rather than being suggestions in a prompt;
+ *   - re-runs on `synchronize` are idempotent — the same finding is never
+ *     posted twice;
+ *   - a line outside the diff cannot 422 the whole review and lose the rest of
+ *     the comments with it.
+ *
+ * Never exits non-zero for review content. A broken reviewer must not break
+ * anyone's CI.
+ */
+
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  commentableLines,
+  createIssueComment,
+  createReview,
+  getPullFiles,
+  getReviewComments,
+} from './lib/github.mjs';
+import { gateFindings, SEVERITY_ORDER } from './lib/scoring.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_PATH = join(HERE, '..', 'rules.json');
+const FINDINGS_PATH = '.claude-review/findings.json';
+const MARKER = 'claude-review';
+
+const REPO = process.env.REPO;
+const PR_NUMBER = process.env.PR_NUMBER;
+const HEAD_SHA = process.env.HEAD_SHA;
+const DIFF_TRUNCATED = process.env.DIFF_TRUNCATED === 'true';
+const REQUEST_CHANGES_ON_BLOCKER = process.env.REQUEST_CHANGES_ON_BLOCKER === '1';
+
+const SEVERITY_LABEL = {
+  blocker: '🔴 Blocker',
+  major: '🟠 Major',
+  minor: '🟡 Minor',
+  nit: '⚪ Nit',
+};
+
+/** Validate a single finding. Returns an error string, or null if it is fine. */
+function validateFinding(f, i) {
+  if (typeof f !== 'object' || f === null) return `finding[${i}] is not an object`;
+  if (!/^[A-Z]+-\d+$/.test(f.ruleId || '')) return `finding[${i}] has a bad ruleId`;
+  if (typeof f.file !== 'string' || !f.file) return `finding[${i}] has no file`;
+  if (!Number.isInteger(f.line) || f.line < 1) return `finding[${i}] has a bad line`;
+  if (!(f.severity in SEVERITY_ORDER)) return `finding[${i}] has a bad severity`;
+  if (typeof f.confidence !== 'number' || f.confidence < 0 || f.confidence > 1)
+    return `finding[${i}] has a bad confidence`;
+  if (typeof f.title !== 'string' || !f.title) return `finding[${i}] has no title`;
+  if (typeof f.body !== 'string' || !f.body) return `finding[${i}] has no body`;
+  return null;
+}
+
+function commentBody(f, rule) {
+  const parts = [`**${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** — ${f.title}`, '', f.body];
+
+  if (f.suggestion) {
+    parts.push('', '```suggestion', f.suggestion.replace(/^```\w*\n?|```$/g, ''), '```');
+  }
+
+  const notes = [];
+  if (f._exploring) {
+    notes.push(
+      'This rule is currently muted because past comments from it were dismissed. ' +
+        'It is being re-tested on this PR — your reaction decides whether it comes back.',
+    );
+  }
+  if (rule.state === 'probation') {
+    notes.push('This rule is on probation; feedback on it is weighted heavily.');
+  }
+  if (notes.length) parts.push('', `> ${notes.join(' ')}`);
+
+  parts.push(
+    '',
+    '<sub>👍 if this was useful, 👎 if it was not — the reviewer tunes itself from these reactions.</sub>',
+    `<!-- ${MARKER} rule=${f.ruleId} fid=${f._fid} conf=${f.confidence} score=${f._score} sev=${f.severity}${f._exploring ? ' explore=1' : ''} -->`,
+  );
+  return parts.join('\n');
+}
+
+function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
+  const counts = { blocker: 0, major: 0, minor: 0, nit: 0 };
+  for (const f of kept) counts[f.severity]++;
+
+  const lines = ['## Claude review', ''];
+  lines.push(summary || '_No summary was produced._', '');
+
+  if (kept.length === 0) {
+    lines.push('No findings above the confidence threshold. Nothing to flag.');
+  } else {
+    lines.push(
+      'Findings: ' +
+        Object.entries(counts)
+          .filter(([, n]) => n > 0)
+          .map(([sev, n]) => `${SEVERITY_LABEL[sev]} ${n}`)
+          .join(' · '),
+    );
+  }
+
+  if (outOfDiff.length) {
+    lines.push(
+      '',
+      '### Findings outside the diff',
+      '',
+      'These could not be attached to a line this PR changed:',
+      '',
+    );
+    for (const f of outOfDiff) {
+      lines.push(`- **${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}`);
+    }
+  }
+
+  const noise = dropped.filter((d) => !/already posted/.test(d.reason));
+  if (noise.length) {
+    lines.push(
+      '',
+      '<details><summary>' + noise.length + ' finding(s) suppressed by the feedback loop</summary>',
+      '',
+    );
+    for (const d of noise) {
+      lines.push(`- \`${d.finding.ruleId}\` ${d.finding.file}:${d.finding.line} — ${d.reason}`);
+    }
+    lines.push('', '</details>');
+  }
+
+  if (invalid.length) {
+    lines.push('', `<sub>${invalid.length} malformed finding(s) discarded: ${invalid.join('; ')}</sub>`);
+  }
+  if (DIFF_TRUNCATED) {
+    lines.push('', '<sub>⚠️ The diff was truncated for size — later files were not reviewed.</sub>');
+  }
+
+  const muted = Object.entries(rules).filter(([, r]) => r.state === 'muted').length;
+  lines.push(
+    '',
+    `<sub>Rulebook v${rules._version ?? '?'} · ${Object.keys(rules).length - 1} rules · ${muted} muted. ` +
+      'See `.github/review/review-rules.md`. React 👍/👎 on any comment to tune the reviewer.</sub>',
+    `<!-- ${MARKER} summary -->`,
+  );
+  return lines.join('\n');
+}
+
+async function main() {
+  if (!REPO || !PR_NUMBER) {
+    console.error('REPO and PR_NUMBER must be set.');
+    return;
+  }
+
+  if (!existsSync(FINDINGS_PATH)) {
+    console.log('No findings.json was produced — the review step likely failed. Nothing to post.');
+    return;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(FINDINGS_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`findings.json is not valid JSON: ${err.message}`);
+    return;
+  }
+
+  const book = JSON.parse(readFileSync(RULES_PATH, 'utf8'));
+  const rules = book.rules;
+
+  // --- validate -----------------------------------------------------------
+  const raw = Array.isArray(payload.findings) ? payload.findings : [];
+  const invalid = [];
+  const valid = [];
+  raw.forEach((f, i) => {
+    const err = validateFinding(f, i);
+    if (err) invalid.push(err);
+    else valid.push(f);
+  });
+  console.log(`Parsed ${valid.length} valid finding(s), ${invalid.length} discarded.`);
+
+  // --- idempotency: what did earlier runs already say? --------------------
+  const existing = await getReviewComments(REPO, PR_NUMBER);
+  const alreadyPosted = new Set();
+  for (const c of existing) {
+    const m = new RegExp(`<!-- ${MARKER} .*?fid=([a-z0-9]+)`).exec(c.body || '');
+    if (m) alreadyPosted.add(m[1]);
+  }
+  console.log(`${alreadyPosted.size} finding(s) already posted on this PR.`);
+
+  // --- gate against learned weights ---------------------------------------
+  const { kept, dropped } = gateFindings(valid, rules, {
+    prNumber: PR_NUMBER,
+    maxComments: book.defaults?.maxCommentsPerPR ?? 12,
+    explorationPercent: book.defaults?.explorationPercent ?? 10,
+    alreadyPosted,
+  });
+  console.log(`${kept.length} finding(s) passed the gate, ${dropped.length} dropped.`);
+
+  // --- map to lines GitHub will accept ------------------------------------
+  const files = await getPullFiles(REPO, PR_NUMBER);
+  const lineIndex = new Map();
+  for (const file of files) lineIndex.set(file.filename, commentableLines(file.patch));
+
+  const inline = [];
+  const outOfDiff = [];
+  for (const f of kept) {
+    const allowed = lineIndex.get(f.file);
+    if (!allowed || !allowed.has(f.line)) {
+      outOfDiff.push(f);
+      continue;
+    }
+    const comment = {
+      path: f.file,
+      line: f.line,
+      side: 'RIGHT',
+      body: commentBody(f, rules[f.ruleId]),
+    };
+    // Multi-line comments need start_line to also be in the diff.
+    if (Number.isInteger(f.endLine) && f.endLine > f.line && allowed.has(f.endLine)) {
+      comment.start_line = f.line;
+      comment.start_side = 'RIGHT';
+      comment.line = f.endLine;
+    }
+    inline.push(comment);
+  }
+  if (outOfDiff.length) {
+    console.log(`${outOfDiff.length} finding(s) fell outside the diff; moved into the summary.`);
+  }
+
+  const hasBlocker = kept.some((f) => f.severity === 'blocker');
+  const body = summaryBody({
+    summary: payload.summary,
+    kept,
+    dropped,
+    outOfDiff,
+    invalid,
+    rules: { ...rules, _version: book.version },
+  });
+
+  // Nothing new to say and nothing already said: stay quiet.
+  if (inline.length === 0 && outOfDiff.length === 0 && alreadyPosted.size > 0) {
+    console.log('No new findings since the last run. Not posting.');
+    return;
+  }
+
+  writeFileSync('.claude-review/posted.json', JSON.stringify({ inline, outOfDiff, dropped }, null, 2));
+
+  try {
+    await createReview(REPO, PR_NUMBER, {
+      commitId: HEAD_SHA,
+      body,
+      event: hasBlocker && REQUEST_CHANGES_ON_BLOCKER ? 'REQUEST_CHANGES' : 'COMMENT',
+      comments: inline,
+    });
+    console.log(`Posted a review with ${inline.length} inline comment(s).`);
+  } catch (err) {
+    // The review API is all-or-nothing. Rather than lose the whole review to
+    // one bad line reference, fall back to a single summary comment.
+    console.error(`Inline review failed, falling back to a summary comment: ${err.message}`);
+    const fallback = [
+      body,
+      '',
+      '### Findings',
+      '',
+      ...kept.map(
+        (f) =>
+          `- **${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}\n\n  ${f.body.replace(/\n/g, '\n  ')}`,
+      ),
+    ].join('\n');
+    try {
+      await createIssueComment(REPO, PR_NUMBER, fallback);
+      console.log('Posted the fallback summary comment.');
+    } catch (err2) {
+      console.error(`Fallback comment also failed: ${err2.message}`);
+    }
+  }
+}
+
+main().catch((err) => {
+  // Log loudly, exit clean. The reviewer is advisory; it must never be the
+  // reason a pull request cannot merge.
+  console.error(`post-review failed: ${err.stack || err.message}`);
+});

--- a/.github/review/scripts/sync-rules.mjs
+++ b/.github/review/scripts/sync-rules.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Keeps review-rules.md (the human rulebook) and rules.json (the learned state)
+ * in agreement.
+ *
+ *   node sync-rules.mjs --check   exit 1 if they disagree  (runs in CI)
+ *   node sync-rules.mjs --write   add new rules, retire removed ones
+ *
+ * Learned stats are never discarded by --write: a rule removed from the
+ * markdown moves into the `retired` block with its history intact, and comes
+ * back with that history if it is ever re-added.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { computeState, computeWeight, evidenceCount, PRIOR_ALPHA, PRIOR_BETA, round3 } from './lib/scoring.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MD_PATH = join(HERE, '..', 'review-rules.md');
+const JSON_PATH = join(HERE, '..', 'rules.json');
+
+const SEED_WEIGHT = round3(PRIOR_ALPHA / (PRIOR_ALPHA + PRIOR_BETA)); // 0.7
+
+/** Extract `**ID · severity · Title.**` headings from the rulebook. */
+export function parseRulebook(markdown) {
+  const re = /^\*\*([A-Z]+-\d+)\s*[·.]\s*(blocker|major|minor|nit)\s*[·.]\s*([^*]+?)\*\*/gm;
+  const rules = {};
+  const seen = new Set();
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    const [, id, severity, title] = m;
+    if (seen.has(id)) throw new Error(`Duplicate rule id in review-rules.md: ${id}`);
+    seen.add(id);
+    rules[id] = { title: title.trim().replace(/\.$/, ''), severity };
+  }
+  return rules;
+}
+
+function emptyStats() {
+  return { accepted: 0, rejected: 0, ignored: 0 };
+}
+
+function load() {
+  const md = parseRulebook(readFileSync(MD_PATH, 'utf8'));
+  let book;
+  try {
+    book = JSON.parse(readFileSync(JSON_PATH, 'utf8'));
+  } catch {
+    book = null;
+  }
+  if (!book) {
+    book = {
+      version: 0,
+      updatedAt: null,
+      defaults: { maxCommentsPerPR: 12, explorationPercent: 10 },
+      rules: {},
+      retired: {},
+    };
+  }
+  book.retired ||= {};
+  return { md, book };
+}
+
+function reconcile(md, book) {
+  const problems = [];
+  const rules = {};
+
+  for (const [id, meta] of Object.entries(md)) {
+    const existing = book.rules[id] || book.retired[id];
+    if (!existing) {
+      problems.push(`rules.json is missing ${id} (present in review-rules.md)`);
+      rules[id] = {
+        title: meta.title,
+        severity: meta.severity,
+        weight: SEED_WEIGHT,
+        state: 'active',
+        stats: emptyStats(),
+        history: [],
+      };
+      continue;
+    }
+
+    const stats = { ...emptyStats(), ...(existing.stats || {}) };
+    const weight = computeWeight(stats);
+    const state = computeState(weight, evidenceCount(stats));
+
+    if (existing.title !== meta.title) problems.push(`${id}: title differs from review-rules.md`);
+    if (existing.severity !== meta.severity) problems.push(`${id}: severity differs from review-rules.md`);
+    if (existing.weight !== weight) problems.push(`${id}: weight ${existing.weight} does not match stats (${weight})`);
+    if (existing.state !== state) problems.push(`${id}: state ${existing.state} does not match weight (${state})`);
+    if (book.retired[id]) problems.push(`${id}: listed as retired but present in review-rules.md`);
+
+    rules[id] = {
+      title: meta.title,
+      severity: meta.severity,
+      weight,
+      state,
+      stats,
+      history: existing.history || [],
+    };
+  }
+
+  const retired = { ...book.retired };
+  for (const id of Object.keys(book.rules)) {
+    if (md[id]) continue;
+    problems.push(`${id} is in rules.json but not in review-rules.md (will be retired)`);
+    retired[id] = { ...book.rules[id], retired: true };
+  }
+  for (const id of Object.keys(md)) delete retired[id];
+
+  return { rules, retired, problems };
+}
+
+function main() {
+  const mode = process.argv.includes('--write') ? 'write' : 'check';
+  const { md, book } = load();
+  const count = Object.keys(md).length;
+  if (count === 0) {
+    console.error('No rules parsed from review-rules.md — check the heading format.');
+    process.exit(1);
+  }
+
+  const { rules, retired, problems } = reconcile(md, book);
+
+  if (mode === 'check') {
+    if (problems.length) {
+      console.error(`rules.json is out of sync with review-rules.md (${problems.length} problem(s)):`);
+      for (const p of problems) console.error(`  - ${p}`);
+      console.error('\nRun: node .github/review/scripts/sync-rules.mjs --write');
+      process.exit(1);
+    }
+    console.log(`rules.json is in sync (${count} rules).`);
+    return;
+  }
+
+  const next = {
+    version: (book.version || 0) + (problems.length ? 1 : 0),
+    updatedAt: process.env.SYNC_TIMESTAMP || book.updatedAt,
+    defaults: book.defaults || { maxCommentsPerPR: 12, explorationPercent: 10 },
+    rules,
+    retired,
+  };
+  writeFileSync(JSON_PATH, JSON.stringify(next, null, 2) + '\n');
+  console.log(`Wrote rules.json: ${count} active rules, ${Object.keys(retired).length} retired.`);
+  for (const p of problems) console.log(`  - ${p}`);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) main();

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -1,0 +1,449 @@
+/**
+ * Tests for the OpenRouter path.
+ *
+ * The pure functions are tested directly; the runner is exercised end to end
+ * against a stub OpenRouter server, because the failure modes that actually
+ * bite with free models — narrated JSON, invented file paths, invented rule
+ * IDs, 429s mid-run — only show up in the full pipeline.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  buildRulesDigest,
+  chooseModels,
+  extractJson,
+  packChunks,
+  splitDiffByFile,
+} from '../lib/openrouter.mjs';
+
+const run = promisify(execFile);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, '..', 'openrouter-review.mjs');
+
+// --- diff splitting --------------------------------------------------------
+
+const DIFF = `diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,4 @@
+ const x = 1;
++const y = 2;
+diff --git a/src/b.ts b/src/b.ts
+index 333..444 100644
+--- a/src/b.ts
++++ b/src/b.ts
+@@ -10,2 +10,3 @@
++const z = 3;
+`;
+
+test('splits a diff into per-file sections keyed by the new path', () => {
+  const files = splitDiffByFile(DIFF);
+  assert.deepEqual(files.map((f) => f.file), ['src/a.ts', 'src/b.ts']);
+  assert.match(files[0].patch, /const y = 2/);
+  assert.ok(!files[0].patch.includes('const z = 3'), 'sections must not bleed into each other');
+});
+
+test('a renamed file is keyed by its new path', () => {
+  const renamed = 'diff --git a/old/name.ts b/new/name.ts\n--- a/old/name.ts\n+++ b/new/name.ts\n@@ -1 +1 @@\n+x\n';
+  assert.equal(splitDiffByFile(renamed)[0].file, 'new/name.ts');
+});
+
+test('an empty diff yields no sections', () => {
+  assert.deepEqual(splitDiffByFile(''), []);
+  assert.deepEqual(splitDiffByFile('   '), []);
+});
+
+// --- chunk packing ---------------------------------------------------------
+
+const mkFiles = (sizes) => sizes.map((n, i) => ({ file: `f${i}.ts`, patch: 'x'.repeat(n) }));
+
+test('small files are packed together into one request', () => {
+  const { chunks } = packChunks(mkFiles([100, 100, 100]), { budgetChars: 1000, maxChunks: 4 });
+  assert.equal(chunks.length, 1);
+  assert.equal(chunks[0].length, 3);
+});
+
+test('files are split across requests once the budget is exceeded', () => {
+  const { chunks } = packChunks(mkFiles([600, 600, 600]), { budgetChars: 1000, maxChunks: 4 });
+  assert.equal(chunks.length, 3);
+});
+
+test('a file larger than the budget is truncated rather than dropped', () => {
+  const { chunks, truncated } = packChunks(mkFiles([5000]), { budgetChars: 1000, maxChunks: 4 });
+  assert.deepEqual(truncated, ['f0.ts']);
+  assert.equal(chunks.length, 1);
+  assert.match(chunks[0][0].patch, /diff truncated for length/);
+  assert.ok(chunks[0][0].patch.length <= 1100);
+});
+
+test('the request cap reports what it dropped instead of silently truncating', () => {
+  const { chunks, skipped } = packChunks(mkFiles([900, 900, 900, 900]), { budgetChars: 1000, maxChunks: 2 });
+  assert.equal(chunks.length, 2);
+  assert.equal(skipped.length, 2);
+});
+
+test('one huge file does not starve the small ones behind it', () => {
+  // With only one request available and a file that fills the whole budget,
+  // the small file must still be the one that gets reviewed.
+  const { chunks, skipped } = packChunks(
+    [{ file: 'big.ts', patch: 'x'.repeat(1000) }, { file: 'small.ts', patch: 'y'.repeat(10) }],
+    { budgetChars: 1000, maxChunks: 1 },
+  );
+  assert.deepEqual(chunks[0].map((f) => f.file), ['small.ts']);
+  assert.deepEqual(skipped, ['big.ts']);
+});
+
+// --- JSON recovery ---------------------------------------------------------
+
+const OBJ = '{"summary":"ok","findings":[]}';
+
+test('parses a clean JSON reply', () => {
+  assert.deepEqual(extractJson(OBJ), { summary: 'ok', findings: [] });
+});
+
+test('recovers JSON from markdown fences', () => {
+  assert.deepEqual(extractJson('```json\n' + OBJ + '\n```'), { summary: 'ok', findings: [] });
+  assert.deepEqual(extractJson('```\n' + OBJ + '\n```'), { summary: 'ok', findings: [] });
+});
+
+test('recovers JSON despite narration before and after', () => {
+  const narrated = `Sure! Here is my review:\n\n${OBJ}\n\nLet me know if you need more detail.`;
+  assert.deepEqual(extractJson(narrated), { summary: 'ok', findings: [] });
+});
+
+test('strips a reasoning model scratchpad', () => {
+  assert.deepEqual(extractJson(`<think>Let me look at this...</think>\n${OBJ}`), {
+    summary: 'ok',
+    findings: [],
+  });
+});
+
+test('handles braces inside strings without losing the object', () => {
+  const tricky = 'Here:\n{"summary":"use {a: 1} instead","findings":[]}\nDone.';
+  assert.equal(extractJson(tricky).summary, 'use {a: 1} instead');
+});
+
+test('handles escaped quotes inside strings', () => {
+  const tricky = '{"summary":"he said \\"hi\\" then left","findings":[]}';
+  assert.equal(extractJson(tricky).summary, 'he said "hi" then left');
+});
+
+test('returns null rather than guessing on unusable output', () => {
+  assert.equal(extractJson('I cannot review this.'), null);
+  assert.equal(extractJson(''), null);
+  assert.equal(extractJson(null), null);
+  assert.equal(extractJson('{"broken": '), null);
+  assert.equal(extractJson('[1,2,3]'), null, 'a bare array is not the expected shape');
+});
+
+// --- rules digest ----------------------------------------------------------
+
+const RULES = {
+  'SEC-001': { title: 'Injection', severity: 'blocker', state: 'active' },
+  'FE-005': { title: 'Index key', severity: 'minor', state: 'probation' },
+  'TS-004': { title: 'Dead code', severity: 'minor', state: 'muted' },
+};
+
+test('the digest omits muted rules, so the model cannot report them', () => {
+  const { digest, included } = buildRulesDigest(RULES, () => false);
+  assert.ok(!digest.includes('TS-004'));
+  assert.deepEqual(included, ['SEC-001', 'FE-005']);
+});
+
+test('probation rules are included with their severity restriction', () => {
+  const { digest } = buildRulesDigest(RULES, () => false);
+  assert.match(digest, /FE-005 \[minor\] Index key \(only report at blocker\/major severity\)/);
+});
+
+test('an exploration slot puts a muted rule back in play', () => {
+  const { digest, exploring } = buildRulesDigest(RULES, (id) => id === 'TS-004');
+  assert.match(digest, /TS-004/);
+  assert.deepEqual(exploring, ['TS-004']);
+});
+
+test('the digest stays small enough to leave context for the diff', () => {
+  const { digest } = buildRulesDigest(RULES, () => false);
+  assert.ok(digest.length < 500);
+  assert.equal(digest.split('\n').length, 2, 'one line per rule');
+});
+
+// --- model selection -------------------------------------------------------
+
+const AVAILABLE = [
+  { id: 'big/model:free', context: 262144, structured: false },
+  { id: 'mid/model:free', context: 128000, structured: true },
+  { id: 'small/model:free', context: 32000, structured: false },
+];
+
+test('preferred models lead the chain when they are still available', () => {
+  const chain = chooseModels(AVAILABLE, ['mid/model:free'], 3);
+  assert.equal(chain[0].id, 'mid/model:free');
+  assert.equal(chain.length, 3, 'the rest are appended as fallbacks');
+});
+
+test('a preferred model that no longer exists is skipped, not fatal', () => {
+  const chain = chooseModels(AVAILABLE, ['retired/model:free', 'small/model:free'], 2);
+  assert.equal(chain[0].id, 'small/model:free');
+});
+
+test('with no preference the largest context comes first', () => {
+  assert.equal(chooseModels(AVAILABLE, [], 1)[0].id, 'big/model:free');
+});
+
+test('the chain never exceeds the requested length', () => {
+  assert.equal(chooseModels(AVAILABLE, [], 2).length, 2);
+});
+
+// --- end to end ------------------------------------------------------------
+
+async function startStub({ replies, models = AVAILABLE }) {
+  const calls = [];
+  let i = 0;
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      const send = (code, payload) => {
+        res.writeHead(code, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      };
+      if (req.url.endsWith('/models')) {
+        return send(200, {
+          data: models.map((m) => ({
+            id: m.id,
+            context_length: m.context,
+            supported_parameters: m.structured ? ['structured_outputs'] : [],
+          })),
+        });
+      }
+      if (req.url.endsWith('/key')) return send(200, { data: { usage: 1, limit: null } });
+      if (req.url.endsWith('/chat/completions')) {
+        calls.push(JSON.parse(body));
+        const reply = replies[Math.min(i++, replies.length - 1)];
+        if (reply.status && reply.status !== 200) return send(reply.status, { error: reply.body });
+        return send(200, {
+          model: reply.model || 'big/model:free',
+          choices: [{ message: { content: reply.content } }],
+          usage: { total_tokens: 100 },
+        });
+      }
+      send(404, {});
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  return { server, calls, port: server.address().port };
+}
+
+async function runReview(stub, { diff = DIFF, rules, env = {} } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'or-review-'));
+  await mkdir(join(dir, '.claude-review'), { recursive: true });
+  await writeFile(join(dir, '.claude-review', 'pr.diff'), diff);
+
+  // The script reads rules.json relative to itself, so point it at a copy only
+  // when the test needs different rules.
+  let scriptPath = SCRIPT;
+  if (rules) {
+    const reviewDir = join(dir, 'review');
+    await mkdir(join(reviewDir, 'scripts', 'lib'), { recursive: true });
+    await writeFile(join(reviewDir, 'rules.json'), JSON.stringify(rules));
+    for (const f of ['openrouter-review.mjs']) {
+      await writeFile(join(reviewDir, 'scripts', f), await readFile(join(HERE, '..', f)));
+    }
+    for (const f of ['openrouter.mjs', 'scoring.mjs']) {
+      await writeFile(join(reviewDir, 'scripts', 'lib', f), await readFile(join(HERE, '..', 'lib', f)));
+    }
+    scriptPath = join(reviewDir, 'scripts', 'openrouter-review.mjs');
+  }
+
+  const { stdout, stderr } = await run(process.execPath, [scriptPath], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      OPENROUTER_BASE_URL: `http://127.0.0.1:${stub.port}`,
+      OPENROUTER_API_KEY: 'stub-key',
+      PR_NUMBER: '7',
+      ...env,
+    },
+  });
+  const findings = JSON.parse(await readFile(join(dir, '.claude-review', 'findings.json'), 'utf8'));
+  await rm(dir, { recursive: true, force: true });
+  return { stdout, stderr, findings };
+}
+
+const RULES_FILE = {
+  version: 1,
+  defaults: { explorationPercent: 0 },
+  rules: {
+    'SEC-001': { title: 'Injection', severity: 'blocker', state: 'active', weight: 0.7, stats: {} },
+  },
+};
+
+const goodFinding = {
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 2,
+  severity: 'blocker',
+  confidence: 0.9,
+  title: 'SQL injection',
+  body: 'Parameterise this.',
+};
+
+test('produces findings.json in the schema post-review.mjs expects', async () => {
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 'Looks risky.', findings: [goodFinding] }) }],
+  });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1);
+    assert.equal(findings.findings[0].ruleId, 'SEC-001');
+    assert.match(findings.summary, /Looks risky/);
+    assert.equal(typeof findings.findings[0].confidence, 'number');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('narrated and fenced replies still yield findings', async () => {
+  const stub = await startStub({
+    replies: [
+      { content: 'Sure!\n```json\n' + JSON.stringify({ summary: 's', findings: [goodFinding] }) + '\n```\nHope that helps!' },
+    ],
+  });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('invented rule IDs and file paths are discarded', async () => {
+  const stub = await startStub({
+    replies: [
+      {
+        content: JSON.stringify({
+          summary: 's',
+          findings: [
+            { ...goodFinding, ruleId: 'MADE-UP-1' },
+            { ...goodFinding, file: 'src/does-not-exist.ts' },
+            { ...goodFinding, confidence: 0.2 },
+            { ...goodFinding, severity: 'catastrophic' },
+            goodFinding,
+          ],
+        }),
+      },
+    ],
+  });
+  try {
+    const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
+    assert.equal(findings.findings.length, 1, 'only the valid finding survives');
+    assert.match(stdout, /4 rejected/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('an unparseable reply triggers exactly one repair attempt', async () => {
+  const stub = await startStub({
+    replies: [
+      { content: 'I am unable to produce JSON right now.' },
+      { content: JSON.stringify({ summary: 'recovered', findings: [goodFinding] }) },
+    ],
+  });
+  try {
+    const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
+    assert.match(stdout, /retrying once/);
+    assert.equal(findings.findings.length, 1);
+    assert.equal(stub.calls.length, 2);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a rate limited batch degrades to a partial review, not a crash', async () => {
+  const stub = await startStub({ replies: [{ status: 429, body: { message: 'rate limited' } }] });
+  try {
+    const { findings, stderr } = await runReview(stub, { rules: RULES_FILE, env: { MAX_REQUESTS: '1' } });
+    assert.deepEqual(findings.findings, []);
+    assert.match(findings.summary, /failed/i);
+    assert.match(stderr, /429/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a missing API key writes an empty review instead of failing the job', async () => {
+  const stub = await startStub({ replies: [{ content: OBJ }] });
+  try {
+    const { findings } = await runReview(stub, { rules: RULES_FILE, env: { OPENROUTER_API_KEY: '' } });
+    assert.deepEqual(findings.findings, []);
+    assert.match(findings.summary, /no OpenRouter API key/i);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the request budget is respected and what was dropped is reported', async () => {
+  const many = Array.from({ length: 6 }, (_, i) =>
+    `diff --git a/f${i}.ts b/f${i}.ts\n--- a/f${i}.ts\n+++ b/f${i}.ts\n@@ -1 +1,2 @@\n+${'x'.repeat(30000)}\n`,
+  ).join('');
+  const stub = await startStub({ replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }] });
+  try {
+    const { findings, stdout } = await runReview(stub, {
+      diff: many,
+      rules: RULES_FILE,
+      env: { MAX_REQUESTS: '2' },
+    });
+    assert.equal(stub.calls.length, 2, 'never exceeds the request budget');
+    assert.match(stdout, /Skipped \(request cap\)/);
+    assert.match(findings.summary, /request budget/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('the fallback chain is sent so OpenRouter can reroute on rate limits', async () => {
+  const stub = await startStub({ replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }] });
+  try {
+    await runReview(stub, { rules: RULES_FILE });
+    assert.ok(Array.isArray(stub.calls[0].models), 'models array must be present');
+    assert.ok(stub.calls[0].models.length > 1, 'needs at least one fallback');
+    assert.equal(stub.calls[0].temperature, 0.1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('JSON mode is only requested when every model in the chain supports it', async () => {
+  const mixed = await startStub({
+    replies: [{ content: OBJ }],
+    models: [{ id: 'a:free', context: 100000, structured: true }, { id: 'b:free', context: 90000, structured: false }],
+  });
+  try {
+    await runReview(mixed, { rules: RULES_FILE });
+    assert.equal(mixed.calls[0].response_format, undefined, 'would 400 on the non-supporting fallback');
+  } finally {
+    mixed.server.close();
+  }
+
+  const allStructured = await startStub({
+    replies: [{ content: OBJ }],
+    models: [{ id: 'a:free', context: 100000, structured: true }],
+  });
+  try {
+    await runReview(allStructured, { rules: RULES_FILE });
+    assert.deepEqual(allStructured.calls[0].response_format, { type: 'json_object' });
+  } finally {
+    allStructured.server.close();
+  }
+});

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -1,0 +1,209 @@
+/**
+ * End-to-end test for post-review.mjs against a stub GitHub API.
+ *
+ * Runs the real script as a child process with GITHUB_API_URL pointed at a
+ * local server, so the whole path — parse, validate, gate, diff-map, post — is
+ * exercised without touching the network. This is what catches the failures
+ * that unit tests on pure functions cannot: a wrong request body, a comment on
+ * a line outside the diff, or a crash on malformed model output.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const run = promisify(execFile);
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, '..', 'post-review.mjs');
+
+const PATCH = ['@@ -1,3 +1,5 @@', ' const a = 1;', '+const b = 2;', '+const c = 3;', ' const d = 4;'].join('\n');
+
+/** Stub GitHub API. Records every request so the test can assert on them. */
+async function startStub({ existingComments = [], failReview = false } = {}) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      requests.push({ method: req.method, url: req.url, body: body ? JSON.parse(body) : null });
+      const send = (code, payload) => {
+        res.writeHead(code, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      };
+
+      if (req.url.startsWith('/repos/acme/app/pulls/7/comments')) return send(200, existingComments);
+      if (req.url.startsWith('/repos/acme/app/pulls/7/files')) {
+        return send(200, [{ filename: 'src/a.ts', patch: PATCH }]);
+      }
+      if (req.url.startsWith('/repos/acme/app/pulls/7/reviews')) {
+        return failReview ? send(422, { message: 'line must be part of the diff' }) : send(200, { id: 1 });
+      }
+      if (req.url.startsWith('/repos/acme/app/issues/7/comments')) return send(201, { id: 2 });
+      send(404, { message: 'not found' });
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  return { server, requests, port: server.address().port };
+}
+
+async function runPostReview(findings, stub, env = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-review-'));
+  await mkdir(join(dir, '.claude-review'), { recursive: true });
+  if (findings !== null) {
+    await writeFile(
+      join(dir, '.claude-review', 'findings.json'),
+      typeof findings === 'string' ? findings : JSON.stringify(findings),
+    );
+  }
+  const { stdout, stderr } = await run(process.execPath, [SCRIPT], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      GITHUB_API_URL: `http://127.0.0.1:${stub.port}`,
+      GITHUB_TOKEN: 'stub-token',
+      REPO: 'acme/app',
+      PR_NUMBER: '7',
+      HEAD_SHA: 'deadbeef',
+      ...env,
+    },
+  });
+  await rm(dir, { recursive: true, force: true });
+  return { stdout, stderr };
+}
+
+const findingsPayload = (findings) => ({ summary: 'Looks reasonable overall.', findings });
+
+const base = {
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 2,
+  severity: 'blocker',
+  confidence: 0.9,
+  title: 'SQL built by string concatenation',
+  body: 'Use a parameterised query here.',
+};
+
+test('posts one review with an inline comment on a line inside the diff', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([base]), stub);
+    const review = stub.requests.find((r) => r.method === 'POST' && r.url.includes('/reviews'));
+    assert.ok(review, 'a review should have been posted');
+    assert.equal(review.body.commit_id, 'deadbeef');
+    assert.equal(review.body.event, 'COMMENT');
+    assert.equal(review.body.comments.length, 1);
+    assert.equal(review.body.comments[0].path, 'src/a.ts');
+    assert.equal(review.body.comments[0].line, 2);
+    assert.equal(review.body.comments[0].side, 'RIGHT');
+    assert.match(review.body.comments[0].body, /<!-- claude-review rule=SEC-001 fid=\w+/);
+    assert.match(review.body.body, /## Claude review/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a finding outside the diff is moved into the summary, not sent inline', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([{ ...base, line: 999 }]), stub);
+    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    assert.equal(review.body.comments.length, 0, 'must not send an out-of-diff line');
+    assert.match(review.body.body, /Findings outside the diff/);
+    assert.match(review.body.body, /src\/a\.ts:999/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('REQUEST_CHANGES only when explicitly enabled', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([base]), stub, { REQUEST_CHANGES_ON_BLOCKER: '1' });
+    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    assert.equal(review.body.event, 'REQUEST_CHANGES');
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a finding already posted on an earlier run is not reposted', async () => {
+  const existing = [
+    {
+      id: 100,
+      body: 'old\n<!-- claude-review rule=SEC-001 fid=' + (await import('../lib/scoring.mjs')).findingId(base) + ' -->',
+    },
+  ];
+  const stub = await startStub({ existingComments: existing });
+  try {
+    const { stdout } = await runPostReview(findingsPayload([base]), stub);
+    assert.match(stdout, /No new findings since the last run/);
+    assert.equal(stub.requests.filter((r) => r.method === 'POST').length, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('falls back to a plain comment when the inline review is rejected', async () => {
+  const stub = await startStub({ failReview: true });
+  try {
+    const { stdout } = await runPostReview(findingsPayload([base]), stub);
+    const fallback = stub.requests.find((r) => r.url.includes('/issues/7/comments'));
+    assert.ok(fallback, 'should fall back rather than lose the review');
+    assert.match(fallback.body.body, /SQL built by string concatenation/);
+    assert.match(stdout, /fallback/i);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('malformed model output is discarded without crashing', async () => {
+  const stub = await startStub();
+  try {
+    const { stdout } = await runPostReview(
+      findingsPayload([
+        { ...base, ruleId: 'lowercase-id' },
+        { ...base, line: 'not a number' },
+        { ...base, severity: 'catastrophic' },
+        { ...base, confidence: 7 },
+        base,
+      ]),
+      stub,
+    );
+    assert.match(stdout, /Parsed 1 valid finding\(s\), 4 discarded/);
+    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    assert.equal(review.body.comments.length, 1);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('invalid JSON and a missing file are both survivable', async () => {
+  for (const input of ['{ not json', null]) {
+    const stub = await startStub();
+    try {
+      const { stdout, stderr } = await runPostReview(input, stub);
+      assert.equal(stub.requests.filter((r) => r.method === 'POST').length, 0);
+      assert.ok(/not valid JSON|No findings.json/.test(stdout + stderr));
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+test('a clean PR still gets a short summary', async () => {
+  const stub = await startStub();
+  try {
+    await runPostReview(findingsPayload([]), stub);
+    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    assert.equal(review.body.comments.length, 0);
+    assert.match(review.body.body, /No findings above the confidence threshold/);
+  } finally {
+    stub.server.close();
+  }
+});

--- a/.github/review/scripts/test/scoring.test.mjs
+++ b/.github/review/scripts/test/scoring.test.mjs
@@ -1,0 +1,322 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  computeWeight,
+  computeState,
+  evidenceCount,
+  gateFindings,
+  findingId,
+  isExplorationSlot,
+  decayFactor,
+  rebuildRules,
+  SEVERITY_GATES,
+} from '../lib/scoring.mjs';
+import { commentableLines } from '../lib/github.mjs';
+import { parseMarker, scoreComment } from '../tune-rules.mjs';
+import { parseRulebook } from '../sync-rules.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REVIEW_DIR = join(HERE, '..', '..');
+
+const NOW = '2026-08-07T00:00:00Z';
+const rule = (over = {}) => ({
+  title: 't',
+  severity: 'major',
+  weight: 0.7,
+  state: 'active',
+  stats: { accepted: 0, rejected: 0, ignored: 0 },
+  history: [],
+  ...over,
+});
+const finding = (over = {}) => ({
+  ruleId: 'SEC-001',
+  file: 'src/a.ts',
+  line: 10,
+  severity: 'major',
+  confidence: 0.8,
+  title: 'x',
+  body: 'y',
+  ...over,
+});
+
+// --- weights ---------------------------------------------------------------
+
+test('a fresh rule sits exactly at the 0.7 prior', () => {
+  assert.equal(computeWeight({ accepted: 0, rejected: 0, ignored: 0 }), 0.7);
+});
+
+test('acceptances raise the weight, rejections lower it', () => {
+  const up = computeWeight({ accepted: 10, rejected: 0, ignored: 0 });
+  const down = computeWeight({ accepted: 0, rejected: 10, ignored: 0 });
+  assert.ok(up > 0.7, `expected >0.7, got ${up}`);
+  assert.ok(down < 0.3, `expected <0.3, got ${down}`);
+  assert.ok(up <= 1 && down >= 0);
+});
+
+test('an ignored comment counts less than an outright rejection', () => {
+  const ignored = computeWeight({ accepted: 0, rejected: 0, ignored: 10 });
+  const rejected = computeWeight({ accepted: 0, rejected: 10, ignored: 0 });
+  assert.ok(ignored > rejected);
+});
+
+test('one bad reaction cannot mute a rule', () => {
+  const stats = { accepted: 0, rejected: 1, ignored: 0 };
+  assert.equal(computeState(computeWeight(stats), evidenceCount(stats)), 'active');
+});
+
+test('a consistently dismissed rule is muted once evidence accumulates', () => {
+  const stats = { accepted: 0, rejected: 12, ignored: 0 };
+  assert.equal(computeState(computeWeight(stats), evidenceCount(stats)), 'muted');
+});
+
+test('a mixed rule lands on probation rather than muted', () => {
+  const stats = { accepted: 2, rejected: 6, ignored: 0 };
+  const w = computeWeight(stats);
+  assert.ok(w >= 0.3 && w < 0.5, `weight ${w} should be in the probation band`);
+  assert.equal(computeState(w, evidenceCount(stats)), 'probation');
+});
+
+// --- decay -----------------------------------------------------------------
+
+test('feedback decays with a 90-day half-life', () => {
+  assert.equal(decayFactor(NOW, NOW), 1);
+  const ninetyDaysAgo = new Date(Date.parse(NOW) - 90 * 86_400_000).toISOString();
+  assert.ok(Math.abs(decayFactor(ninetyDaysAgo, NOW) - 0.5) < 0.01);
+  const yearAgo = new Date(Date.parse(NOW) - 365 * 86_400_000).toISOString();
+  assert.ok(decayFactor(yearAgo, NOW) < 0.1);
+});
+
+test('a rule recovers as old rejections age out', () => {
+  const old = new Date(Date.parse(NOW) - 400 * 86_400_000).toISOString();
+  const rules = { 'SEC-001': rule({ weight: 0.2, state: 'muted' }) };
+  const outcomes = Array.from({ length: 12 }, () => ({
+    ruleId: 'SEC-001',
+    outcome: 'rejected',
+    at: old,
+  }));
+  const { rules: next } = rebuildRules(rules, outcomes, NOW);
+  assert.ok(next['SEC-001'].weight > 0.5, 'stale rejections should stop dominating');
+  assert.equal(next['SEC-001'].state, 'active');
+});
+
+test('rebuild is idempotent and recomputes from the ledger, not from prior stats', () => {
+  const rules = { 'SEC-001': rule({ stats: { accepted: 99, rejected: 0, ignored: 0 } }) };
+  const outcomes = [{ ruleId: 'SEC-001', outcome: 'rejected', at: NOW }];
+  const a = rebuildRules(rules, outcomes, NOW);
+  const b = rebuildRules(a.rules, outcomes, NOW);
+  assert.equal(a.rules['SEC-001'].stats.accepted, 0, 'stale stats must be discarded');
+  assert.deepEqual(a.rules['SEC-001'].stats, b.rules['SEC-001'].stats);
+  assert.equal(a.rules['SEC-001'].weight, b.rules['SEC-001'].weight);
+  assert.equal(b.changes.length, 0, 'a second identical run changes nothing');
+});
+
+test('rebuild records what changed', () => {
+  const rules = { 'SEC-001': rule() };
+  const outcomes = Array.from({ length: 12 }, () => ({ ruleId: 'SEC-001', outcome: 'rejected', at: NOW }));
+  const { changes } = rebuildRules(rules, outcomes, NOW);
+  assert.equal(changes.length, 1);
+  assert.deepEqual(changes[0].state, ['active', 'muted']);
+});
+
+// --- gating ----------------------------------------------------------------
+
+test('a healthy rule with a confident finding gets posted', () => {
+  const { kept } = gateFindings([finding()], { 'SEC-001': rule() }, { prNumber: 1 });
+  assert.equal(kept.length, 1);
+  assert.equal(kept[0]._score, 0.56);
+});
+
+test('a low-weight rule is filtered out even at high confidence', () => {
+  const { kept, dropped } = gateFindings(
+    [finding({ confidence: 0.9 })],
+    { 'SEC-001': rule({ weight: 0.35 }) },
+    { prNumber: 1 },
+  );
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /below major gate/);
+});
+
+test('unknown rule ids are dropped, not posted', () => {
+  const { kept, dropped } = gateFindings([finding({ ruleId: 'NOPE-999' })], {}, { prNumber: 1 });
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /unknown rule/);
+});
+
+test('muted rules stay silent on ordinary pull requests', () => {
+  const rules = { 'SEC-001': rule({ state: 'muted', weight: 0.2 }) };
+  let silent = 0;
+  for (let pr = 1; pr <= 100; pr++) {
+    const { kept } = gateFindings([finding()], rules, { prNumber: pr, explorationPercent: 10 });
+    if (kept.length === 0) silent++;
+  }
+  assert.ok(silent >= 85 && silent < 100, `expected ~90 silent PRs, got ${silent}`);
+});
+
+test('an exploration slot actually posts, bypassing the score gate', () => {
+  // Regression guard: a muted rule's weight can never clear the gate, so if
+  // exploration did not bypass it, muted rules could never recover and the
+  // whole mechanism would be dead code.
+  const rules = { 'SEC-001': rule({ state: 'muted', weight: 0.15 }) };
+  const explored = [];
+  for (let pr = 1; pr <= 200; pr++) {
+    const { kept } = gateFindings([finding()], rules, { prNumber: pr, explorationPercent: 10 });
+    if (kept.length) explored.push({ pr, kept });
+  }
+  assert.ok(explored.length > 0, 'muted rules must occasionally be re-tested');
+  assert.equal(explored[0].kept[0]._exploring, true, 'explored findings are flagged as such');
+});
+
+test('exploration is deterministic, so re-runs on a PR agree', () => {
+  const a = isExplorationSlot('SEC-001', 42, 10);
+  for (let i = 0; i < 20; i++) assert.equal(isExplorationSlot('SEC-001', 42, 10), a);
+  assert.equal(isExplorationSlot('SEC-001', 42, 0), false, '0% disables exploration');
+});
+
+test('probation suppresses minor and nit findings but keeps blockers', () => {
+  const rules = { 'SEC-001': rule({ state: 'probation', weight: 0.45 }) };
+  const opts = { prNumber: 1 };
+  assert.equal(gateFindings([finding({ severity: 'minor', confidence: 1 })], rules, opts).kept.length, 0);
+  assert.equal(gateFindings([finding({ severity: 'blocker', confidence: 1 })], rules, opts).kept.length, 1);
+});
+
+test('findings already posted are not posted again', () => {
+  const f = finding();
+  const { kept, dropped } = gateFindings([f], { 'SEC-001': rule() }, {
+    prNumber: 1,
+    alreadyPosted: new Set([findingId(f)]),
+  });
+  assert.equal(kept.length, 0);
+  assert.match(dropped[0].reason, /already posted/);
+});
+
+test('finding ids are stable across reruns but distinguish real differences', () => {
+  assert.equal(findingId(finding()), findingId(finding({ body: 'reworded', confidence: 0.99 })));
+  assert.notEqual(findingId(finding()), findingId(finding({ line: 11 })));
+  assert.notEqual(findingId(finding()), findingId(finding({ file: 'src/b.ts' })));
+});
+
+test('the comment cap keeps the most severe findings', () => {
+  const many = [
+    ...Array.from({ length: 8 }, (_, i) => finding({ severity: 'nit', line: 100 + i, confidence: 1 })),
+    finding({ severity: 'blocker', line: 5, confidence: 0.9 }),
+  ];
+  const { kept } = gateFindings(many, { 'SEC-001': rule() }, { prNumber: 1, maxComments: 3 });
+  assert.equal(kept.length, 3);
+  assert.equal(kept[0].severity, 'blocker');
+});
+
+test('gates are ordered so nits need more confidence than blockers', () => {
+  assert.ok(SEVERITY_GATES.blocker < SEVERITY_GATES.major);
+  assert.ok(SEVERITY_GATES.major < SEVERITY_GATES.minor);
+  assert.ok(SEVERITY_GATES.minor < SEVERITY_GATES.nit);
+});
+
+// --- diff parsing ----------------------------------------------------------
+
+const PATCH = [
+  '@@ -1,4 +1,6 @@',
+  ' const a = 1;',
+  '-const b = 2;',
+  '+const b = 3;',
+  '+const c = 4;',
+  ' const d = 5;',
+  ' const e = 6;',
+  '@@ -20,2 +22,3 @@',
+  ' let x;',
+  '+let y;',
+  ' let z;',
+].join('\n');
+
+test('commentable lines follow the new-file numbering', () => {
+  const lines = commentableLines(PATCH);
+  assert.deepEqual([...lines].sort((a, b) => a - b), [1, 2, 3, 4, 5, 22, 23, 24]);
+});
+
+test('lines outside any hunk are not commentable', () => {
+  const lines = commentableLines(PATCH);
+  assert.ok(!lines.has(10));
+  assert.ok(!lines.has(100));
+});
+
+test('an empty or missing patch yields no commentable lines', () => {
+  assert.equal(commentableLines('').size, 0);
+  assert.equal(commentableLines(undefined).size, 0);
+});
+
+// --- marker round-trip -----------------------------------------------------
+
+test('the marker written into a comment can be parsed back out', () => {
+  const body = 'text\n<!-- claude-review rule=SEC-001 fid=abc123 conf=0.8 score=0.56 sev=major -->';
+  assert.deepEqual(parseMarker(body), {
+    rule: 'SEC-001',
+    fid: 'abc123',
+    conf: '0.8',
+    score: '0.56',
+    sev: 'major',
+  });
+});
+
+test('summary markers and foreign comments are ignored', () => {
+  assert.equal(parseMarker('<!-- claude-review summary -->'), null);
+  assert.equal(parseMarker('just a human comment'), null);
+  assert.equal(parseMarker(''), null);
+});
+
+// --- outcome scoring -------------------------------------------------------
+
+const react = (c) => [{ content: c }];
+
+test('an explicit reaction beats every other signal', () => {
+  assert.equal(
+    scoreComment({ reactions: react('-1'), thread: { isOutdated: true }, prClosed: true }).outcome,
+    'rejected',
+  );
+  assert.equal(scoreComment({ reactions: react('+1'), prClosed: false }).outcome, 'accepted');
+});
+
+test('a dismissive reply counts against the rule', () => {
+  const r = scoreComment({ reactions: [], thread: { replies: ['This is a false positive.'] }, prClosed: true });
+  assert.equal(r.outcome, 'rejected');
+  assert.equal(r.signal, 'reply-dismissal');
+});
+
+test('an agreeing reply counts for the rule', () => {
+  const r = scoreComment({ reactions: [], thread: { replies: ['Good catch, fixed.'] }, prClosed: true });
+  assert.equal(r.outcome, 'accepted');
+});
+
+test('code changing under the comment counts as agreement', () => {
+  const r = scoreComment({ reactions: [], thread: { replies: [] }, prClosed: false, isOutdated: true });
+  assert.equal(r.outcome, 'accepted');
+  assert.equal(r.signal, 'code-changed-after-comment');
+});
+
+test('silence scores only once the PR is closed', () => {
+  assert.equal(scoreComment({ reactions: [], thread: {}, prClosed: false }).outcome, 'undecided');
+  assert.equal(scoreComment({ reactions: [], thread: {}, prClosed: true }).outcome, 'ignored');
+});
+
+// --- rulebook integrity ----------------------------------------------------
+
+test('review-rules.md and rules.json describe the same rules', () => {
+  const md = parseRulebook(readFileSync(join(REVIEW_DIR, 'review-rules.md'), 'utf8'));
+  const book = JSON.parse(readFileSync(join(REVIEW_DIR, 'rules.json'), 'utf8'));
+  assert.ok(Object.keys(md).length > 0, 'no rules parsed from the markdown');
+  assert.deepEqual(Object.keys(md).sort(), Object.keys(book.rules).sort());
+  for (const [id, meta] of Object.entries(md)) {
+    assert.equal(book.rules[id].severity, meta.severity, `${id} severity mismatch`);
+    assert.equal(book.rules[id].title, meta.title, `${id} title mismatch`);
+  }
+});
+
+test('every rule carries a severity the gates understand', () => {
+  const book = JSON.parse(readFileSync(join(REVIEW_DIR, 'rules.json'), 'utf8'));
+  for (const [id, r] of Object.entries(book.rules)) {
+    assert.ok(SEVERITY_GATES[r.severity], `${id} has an unknown severity: ${r.severity}`);
+    assert.ok(r.weight >= 0 && r.weight <= 1, `${id} weight out of range`);
+  }
+});

--- a/.github/review/scripts/tune-rules.mjs
+++ b/.github/review/scripts/tune-rules.mjs
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * The learning loop.
+ *
+ * Walks recent pull requests, finds the review comments this agent posted,
+ * works out how humans actually responded to each one, and rebuilds the rule
+ * weights in rules.json from that evidence. Rules whose comments keep getting
+ * dismissed slide into probation and then get muted; rules whose comments get
+ * acted on hold their ground.
+ *
+ * Signals, strongest first:
+ *   👎 reaction .......................... rejected  (explicit, unambiguous)
+ *   👍 reaction .......................... accepted  (explicit, unambiguous)
+ *   human reply matching a dismissal phrase  rejected
+ *   human reply matching an agreement phrase accepted
+ *   comment went outdated ................ accepted  (the flagged code changed
+ *                                                     after we commented on it)
+ *   PR closed, none of the above ......... ignored   (weak negative)
+ *   PR still open, none of the above ..... undecided (not scored yet)
+ *
+ * Every scored comment is written to feedback-ledger.json, and weights are
+ * recomputed from the whole ledger each run. That makes the job idempotent and
+ * lets you correct a mis-scored outcome by editing the ledger by hand.
+ *
+ *   node tune-rules.mjs [--days 30] [--dry-run]
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { getCommentReactions, graphql, rest, restAll } from './lib/github.mjs';
+import { rebuildRules, evidenceCount } from './lib/scoring.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RULES_PATH = join(HERE, '..', 'rules.json');
+const LEDGER_PATH = join(HERE, '..', 'feedback-ledger.json');
+const REPORT_PATH = process.env.REPORT_PATH || 'tuning-report.md';
+
+const REPO = process.env.REPO;
+const NOW = process.env.RUN_TIMESTAMP || new Date().toISOString();
+const MARKER = 'claude-review';
+const MAX_LEDGER_ENTRIES = 5000;
+
+const argv = process.argv.slice(2);
+const DRY_RUN = argv.includes('--dry-run');
+const DAYS = Number(argv[argv.indexOf('--days') + 1]) || Number(process.env.LOOKBACK_DAYS) || 30;
+
+const DISMISSAL = /\b(false positive|not an issue|not a problem|wontfix|won't fix|by design|intentional|disagree|incorrect|irrelevant|out of scope|already handled|no it('?s| is) not)\b/i;
+const AGREEMENT = /\b(good catch|nice catch|great catch|fixed|done|will fix|fixing|addressed|thanks|thank you|agreed|you'?re right|makes sense)\b/i;
+
+function log(...a) {
+  console.log(...a);
+}
+
+function loadLedger() {
+  if (!existsSync(LEDGER_PATH)) return { lastRunAt: null, entries: {} };
+  try {
+    const l = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
+    return { lastRunAt: l.lastRunAt ?? null, entries: l.entries || {} };
+  } catch {
+    return { lastRunAt: null, entries: {} };
+  }
+}
+
+/** Pull the marker fields out of a comment body we wrote. */
+function parseMarker(body = '') {
+  const m = new RegExp(`<!-- ${MARKER} ([^>]*?)-->`).exec(body);
+  if (!m || /summary/.test(m[1])) return null;
+  const out = {};
+  for (const pair of m[1].trim().split(/\s+/)) {
+    const [k, v] = pair.split('=');
+    if (k && v) out[k] = v;
+  }
+  return out.rule && out.fid ? out : null;
+}
+
+/** Which review threads are resolved, keyed by comment databaseId. */
+async function fetchThreadState(repo, prNumber) {
+  const [owner, name] = repo.split('/');
+  const query = `
+    query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
+      repository(owner:$owner, name:$name) {
+        pullRequest(number:$number) {
+          reviewThreads(first:100, after:$cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              isResolved
+              isOutdated
+              comments(first:50) {
+                nodes {
+                  databaseId
+                  body
+                  author { login }
+                  authorAssociation
+                }
+              }
+            }
+          }
+        }
+      }
+    }`;
+
+  const byComment = new Map();
+  let cursor = null;
+  for (let page = 0; page < 10; page++) {
+    let data;
+    try {
+      data = await graphql(query, { owner, name, number: Number(prNumber), cursor });
+    } catch (err) {
+      log(`  GraphQL thread lookup failed (${err.message.slice(0, 120)}); falling back to REST signals only.`);
+      return byComment;
+    }
+    const threads = data?.repository?.pullRequest?.reviewThreads;
+    if (!threads) break;
+
+    for (const t of threads.nodes) {
+      const nodes = t.comments?.nodes || [];
+      const root = nodes[0];
+      if (!root?.databaseId) continue;
+      const replies = nodes.slice(1).filter((c) => !/\[bot\]$/.test(c.author?.login || ''));
+      byComment.set(root.databaseId, {
+        isResolved: t.isResolved,
+        isOutdated: t.isOutdated,
+        replies: replies.map((r) => r.body || ''),
+      });
+    }
+
+    if (!threads.pageInfo.hasNextPage) break;
+    cursor = threads.pageInfo.endCursor;
+  }
+  return byComment;
+}
+
+/**
+ * Decide the outcome for one of our comments.
+ * @returns {{outcome:'accepted'|'rejected'|'ignored'|'undecided', signal:string}}
+ */
+function scoreComment({ reactions, thread, prClosed, isOutdated }) {
+  const has = (c) => reactions.some((r) => r.content === c);
+  if (has('-1')) return { outcome: 'rejected', signal: 'thumbs-down' };
+  if (has('+1') || has('hooray') || has('rocket')) return { outcome: 'accepted', signal: 'thumbs-up' };
+
+  for (const reply of thread?.replies || []) {
+    if (DISMISSAL.test(reply)) return { outcome: 'rejected', signal: 'reply-dismissal' };
+    if (AGREEMENT.test(reply)) return { outcome: 'accepted', signal: 'reply-agreement' };
+  }
+
+  if (isOutdated || thread?.isOutdated) {
+    return { outcome: 'accepted', signal: 'code-changed-after-comment' };
+  }
+
+  if (prClosed) return { outcome: 'ignored', signal: 'pr-closed-no-response' };
+  return { outcome: 'undecided', signal: 'pr-open-no-response' };
+}
+
+async function harvest(ledger) {
+  const since = new Date(Date.parse(NOW) - DAYS * 86_400_000).toISOString();
+  log(`Scanning pull requests in ${REPO} updated since ${since}...`);
+
+  const prs = (
+    await restAll(`/repos/${REPO}/pulls?state=all&sort=updated&direction=desc`, { max: 300 })
+  ).filter((pr) => pr.updated_at >= since);
+  log(`${prs.length} pull request(s) in window.`);
+
+  let scanned = 0;
+  let scored = 0;
+
+  for (const pr of prs) {
+    const comments = await restAll(`/repos/${REPO}/pulls/${pr.number}/comments`, { max: 200 });
+    const ours = comments
+      .map((c) => ({ comment: c, marker: parseMarker(c.body) }))
+      .filter((x) => x.marker);
+    if (ours.length === 0) continue;
+
+    scanned += ours.length;
+    const threads = await fetchThreadState(REPO, pr.number);
+    const prClosed = pr.state === 'closed';
+
+    for (const { comment, marker } of ours) {
+      const prev = ledger.entries[comment.id];
+      // Settled outcomes on a closed PR never change; skip the API calls.
+      if (prev && prev.final) continue;
+
+      const reactions =
+        comment.reactions && comment.reactions.total_count === 0
+          ? []
+          : await getCommentReactions(REPO, comment.id);
+
+      const { outcome, signal } = scoreComment({
+        reactions,
+        thread: threads.get(comment.id),
+        prClosed,
+        // `position: null` on a review comment means the diff moved under it.
+        isOutdated: comment.position === null,
+      });
+
+      if (outcome === 'undecided') continue;
+
+      const explicit = signal === 'thumbs-up' || signal === 'thumbs-down';
+      ledger.entries[comment.id] = {
+        ruleId: marker.rule,
+        fid: marker.fid,
+        pr: pr.number,
+        outcome,
+        signal,
+        explore: marker.explore === '1',
+        at: comment.created_at,
+        // An explicit reaction, or any outcome on a closed PR, is final.
+        final: explicit || prClosed,
+      };
+      scored++;
+    }
+  }
+
+  log(`Examined ${scanned} agent comment(s); ${scored} newly scored.`);
+  return ledger;
+}
+
+function pruneLedger(ledger) {
+  const ids = Object.keys(ledger.entries);
+  if (ids.length <= MAX_LEDGER_ENTRIES) return ledger;
+  const keep = ids
+    .sort((a, b) => Date.parse(ledger.entries[b].at) - Date.parse(ledger.entries[a].at))
+    .slice(0, MAX_LEDGER_ENTRIES);
+  const entries = {};
+  for (const id of keep) entries[id] = ledger.entries[id];
+  return { ...ledger, entries };
+}
+
+function writeReport(book, next, changes, ledger) {
+  const outcomes = Object.values(ledger.entries);
+  const tally = outcomes.reduce((acc, o) => ((acc[o.outcome] = (acc[o.outcome] || 0) + 1), acc), {});
+
+  const lines = [
+    '## Review agent tuning report',
+    '',
+    `Run at ${NOW} over a ${DAYS}-day window.`,
+    '',
+    `Ledger holds ${outcomes.length} scored comment(s): ` +
+      `${tally.accepted || 0} accepted, ${tally.rejected || 0} rejected, ${tally.ignored || 0} ignored.`,
+    '',
+  ];
+
+  if (changes.length === 0) {
+    lines.push('No rule weights changed this run.');
+  } else {
+    lines.push('### Rules that moved', '', '| Rule | Weight | State | Evidence |', '| --- | --- | --- | --- |');
+    for (const c of changes.sort((a, b) => a.weight[1] - b.weight[1])) {
+      const arrow = c.weight[1] < c.weight[0] ? '↓' : '↑';
+      const state = c.state[0] === c.state[1] ? c.state[1] : `**${c.state[0]} → ${c.state[1]}**`;
+      lines.push(
+        `| \`${c.ruleId}\` ${c.title} | ${c.weight[0]} ${arrow} ${c.weight[1]} | ${state} | ` +
+          `${c.stats.accepted}✓ / ${c.stats.rejected}✗ / ${c.stats.ignored}∅ |`,
+      );
+    }
+  }
+
+  const muted = Object.entries(next).filter(([, r]) => r.state === 'muted');
+  const probation = Object.entries(next).filter(([, r]) => r.state === 'probation');
+
+  if (muted.length) {
+    lines.push('', '### Currently muted', '');
+    for (const [id, r] of muted) {
+      lines.push(`- \`${id}\` ${r.title} — weight ${r.weight} over ${evidenceCount(r.stats).toFixed(1)} observations`);
+    }
+    lines.push(
+      '',
+      `Muted rules are still re-tested on roughly ${book.defaults?.explorationPercent ?? 10}% of pull requests, ` +
+        'so a rule that was fixed can earn its way back without anyone intervening.',
+    );
+  }
+  if (probation.length) {
+    lines.push('', '### On probation (blocker/major findings only)', '');
+    for (const [id, r] of probation) lines.push(`- \`${id}\` ${r.title} — weight ${r.weight}`);
+  }
+
+  const gen = outcomes.filter((o) => o.ruleId === 'GEN-000' && o.outcome === 'accepted').length;
+  if (gen > 0) {
+    lines.push(
+      '',
+      `### Worth a look`,
+      '',
+      `${gen} accepted \`GEN-000\` finding(s) in the ledger — real problems no rule covers yet. ` +
+        'Read them and consider promoting the recurring ones into `review-rules.md`.',
+    );
+  }
+
+  lines.push(
+    '',
+    '---',
+    '',
+    'Weights are the mean of a Beta posterior per rule, seeded at 0.7 and updated from human ' +
+      'reactions, thread replies, and whether the flagged code actually changed. Observations ' +
+      'decay with a 90-day half-life so the rulebook reflects how each rule behaves now.',
+  );
+
+  const report = lines.join('\n');
+  writeFileSync(REPORT_PATH, report + '\n');
+  return report;
+}
+
+async function main() {
+  if (!REPO) throw new Error('REPO must be set (owner/name).');
+
+  const book = JSON.parse(readFileSync(RULES_PATH, 'utf8'));
+  let ledger = loadLedger();
+
+  ledger = pruneLedger(await harvest(ledger));
+
+  const outcomes = Object.values(ledger.entries).map((e) => ({
+    ruleId: e.ruleId,
+    outcome: e.outcome,
+    at: e.at,
+  }));
+
+  const { rules: nextRules, changes } = rebuildRules(book.rules, outcomes, NOW);
+  const report = writeReport(book, nextRules, changes, ledger);
+
+  log('');
+  log(report);
+  log('');
+
+  if (DRY_RUN) {
+    log('--dry-run: nothing written.');
+    return;
+  }
+
+  if (changes.length === 0) {
+    log('No weight changes; leaving rules.json untouched.');
+    ledger.lastRunAt = NOW;
+    writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n');
+    if (process.env.GITHUB_OUTPUT) {
+      writeFileSync(process.env.GITHUB_OUTPUT, 'changed=false\n', { flag: 'a' });
+    }
+    return;
+  }
+
+  writeFileSync(
+    RULES_PATH,
+    JSON.stringify({ ...book, version: (book.version || 0) + 1, updatedAt: NOW, rules: nextRules }, null, 2) + '\n',
+  );
+  ledger.lastRunAt = NOW;
+  writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n');
+
+  log(`Updated ${changes.length} rule(s); rulebook is now v${(book.version || 0) + 1}.`);
+  if (process.env.GITHUB_OUTPUT) {
+    writeFileSync(process.env.GITHUB_OUTPUT, `changed=true\nchange_count=${changes.length}\n`, { flag: 'a' });
+  }
+}
+
+// Only run when invoked directly, so the scoring helpers above stay importable
+// from the test file.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(`tune-rules failed: ${err.stack || err.message}`);
+    process.exit(1);
+  });
+}
+
+export { scoreComment, parseMarker };

--- a/.github/workflows/claude-review-tuning.yml
+++ b/.github/workflows/claude-review-tuning.yml
@@ -1,0 +1,109 @@
+name: Claude Review Tuning
+
+# Two jobs:
+#   validate — on any PR that touches the review config, prove that
+#              review-rules.md and rules.json still agree.
+#   tune     — weekly, harvest human feedback on past review comments, rebuild
+#              the rule weights, and open a PR with the change.
+#
+# The tuning job never pushes to the default branch directly. A human always
+# sees which rules are about to be muted and why.
+
+on:
+  pull_request:
+    paths:
+      - '.github/review/**'
+      - '.github/workflows/claude-review-tuning.yml'
+  schedule:
+    # 04:00 UTC every Monday (09:30 IST).
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Lookback window in days'
+        required: false
+        default: '30'
+      dry_run:
+        description: 'Report only, do not open a PR'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check rules.json matches review-rules.md
+        run: node .github/review/scripts/sync-rules.mjs --check
+      - name: Unit tests
+        run: node --test '.github/review/scripts/test/*.test.mjs'
+
+  tune:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Harvest feedback and rebuild weights
+        id: tune
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.days || '30' }}
+          REPORT_PATH: tuning-report.md
+        run: |
+          node .github/review/scripts/tune-rules.mjs \
+            ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
+
+      - name: Job summary
+        if: always()
+        run: cat tuning-report.md >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Open tuning pull request
+        if: steps.tune.outputs.changed == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/claude-review-tuning
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CHANGE_COUNT: ${{ steps.tune.outputs.change_count }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add .github/review/rules.json .github/review/feedback-ledger.json
+          git commit \
+            -m "chore(review): retune rule weights from PR feedback" \
+            -m "${CHANGE_COUNT} rule(s) changed. See the PR body for which moved and why."
+          git push --force origin "$BRANCH"
+
+          # Label is optional; create it once, ignore the error if it exists.
+          gh label create claude-review-tuning \
+            --color BFD4F2 --description "Automated review rule weight updates" 2>/dev/null || true
+
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            gh pr edit "$BRANCH" --body-file tuning-report.md
+            echo "Updated the existing tuning PR."
+          else
+            gh pr create \
+              --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH" \
+              --title "chore(review): retune rule weights from PR feedback" \
+              --body-file tuning-report.md \
+              --label "claude-review-tuning"
+          fi

--- a/.github/workflows/claude-review-tuning.yml
+++ b/.github/workflows/claude-review-tuning.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Check rules.json matches review-rules.md
         run: node .github/review/scripts/sync-rules.mjs --check
       - name: Unit tests
-        run: node --test '.github/review/scripts/test/*.test.mjs'
+        # Unquoted so the shell expands it. `node --test` only expands globs
+        # itself on Node 21+, and this workflow pins Node 20.
+        run: node --test .github/review/scripts/test/*.test.mjs
 
   tune:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,97 @@
+name: PR Review
+
+# Automated PR review using OpenRouter free models.
+#
+# Same three-step shape as before — prepare the diff, generate findings, post
+# them — but the middle step is now a plain script calling OpenRouter instead of
+# an agentic action. post-review.mjs, the rule gating and the feedback loop are
+# untouched: only the thing producing findings.json changed.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Prepare diff
+        id: prep
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p .claude-review
+
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+
+          git diff --unified=3 "$MERGE_BASE" "$HEAD_SHA" \
+            -- . ':(exclude)**/*.lock' ':(exclude)**/package-lock.json' \
+               ':(exclude)**/yarn.lock' ':(exclude)**/pnpm-lock.yaml' \
+               ':(exclude)**/*.snap' ':(exclude)**/dist/**' \
+               ':(exclude)**/build/**' ':(exclude)**/*.min.js' \
+            > .claude-review/pr.diff
+
+          git diff --name-status "$MERGE_BASE" "$HEAD_SHA" > .claude-review/changed-files.txt
+
+          BYTES=$(wc -c < .claude-review/pr.diff)
+          echo "diff_bytes=$BYTES" >> "$GITHUB_OUTPUT"
+          echo "Diff: ${BYTES} bytes, $(wc -l < .claude-review/changed-files.txt) file(s)."
+
+      - name: Generate findings
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # Optional. Preferred models, best first — any that are no longer free
+          # are skipped and the script falls back to whatever currently is.
+          # Leave unset to just use the largest-context free models available.
+          OPENROUTER_MODELS: ${{ vars.OPENROUTER_MODELS }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Passed as env, not interpolated into a shell command — a PR title is
+          # attacker-controlled text and must never reach a `run:` block inline.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          # Each batch is one OpenRouter request. The free tier allows 50 per
+          # day, or 1000 once the account has bought $10 of credit. Four keeps a
+          # busy repo inside the smaller budget.
+          MAX_REQUESTS: '4'
+        run: node .github/review/scripts/openrouter-review.mjs
+
+      - name: Post review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REQUEST_CHANGES_ON_BLOCKER: '0'
+        run: node .github/review/scripts/post-review.mjs
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-${{ github.event.pull_request.number }}
+          path: .claude-review/
+          retention-days: 14
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ This project uses **Husky** to enforce code quality standards before each commit
 
 **Note:** All checks must pass before a commit is allowed. If any check fails, the commit will be blocked until issues are resolved.
 
+## 🤖 Automated PR Review
+
+Every non-draft pull request is reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 56 rules covering security, PHI handling, data access, async correctness, realtime, frontend, TypeScript, tests, and ops.
+
+**How it runs** ([.github/workflows/pr-review.yml](.github/workflows/pr-review.yml)):
+
+1. **Prepare** — computes the diff against the merge base, excluding lockfiles, snapshots, and build output
+2. **Review** — sends the diff and a rules digest to a free OpenRouter model, producing structured findings
+3. **Post** — validates the findings, gates them against learned per-rule weights, and posts one review
+
+**The feedback loop:** each comment carries a hidden marker tying it to a rule ID. A weekly job ([.github/workflows/claude-review-tuning.yml](.github/workflows/claude-review-tuning.yml)) reads how humans responded — 👍/👎 reactions, reply wording, whether the flagged code changed — and retunes each rule's weight. Rules the team keeps dismissing go to probation, then mute. Muted rules are re-tested on ~10% of PRs so a rule that was genuinely fixed earns its way back.
+
+**React to the comments.** 👍 and 👎 are the only unambiguous signal the loop gets.
+
+**Required setup:** an `OPENROUTER_API_KEY` repository secret. Turn training **off** for free models in OpenRouter's privacy settings before enabling — diffs of clinical code can carry table names, field names, and fixture data.
+
+**Opting out:** add the `skip-review` label to a PR. The review never blocks a merge; it posts as a comment.
+
+Adding or removing a rule means editing `review-rules.md` and running `node .github/review/scripts/sync-rules.mjs --write`. CI fails any PR where the rulebook and `rules.json` disagree. Full design notes: [.github/review/README.md](.github/review/README.md).
+
 ## 🌐 Access
 
 - **Development**: http://localhost:3000 (optimized port)


### PR DESCRIPTION
## Description

Adds an automated PR review agent that applies a written rulebook to every pull request and gets quieter over time about the rules people keep dismissing.

Unzipped from `pr-review-openrouter.zip` and installed as-is. The OpenRouter variant is the one wired up; the alternate `claude-pr-review.yml` shipped in the package was deleted so PRs are not reviewed twice.

**How it runs** — three steps, in `.github/workflows/pr-review.yml`:

1. **Prepare** — diff against the merge base, excluding lockfiles, snapshots, `dist/`, `build/`, and minified output
2. **Review** — `openrouter-review.mjs` sends the diff plus a rules digest to a free OpenRouter model, writing structured findings
3. **Post** — `post-review.mjs` validates the findings, gates them against learned per-rule weights, maps them onto lines GitHub will accept, and posts one review

The split between steps 2 and 3 is the design: the model decides *what is wrong*, the script decides *what gets said*. The comment cap, confidence thresholds, and mute list are code, not polite requests in a prompt.

**The rulebook** — `.github/review/review-rules.md`, 56 rules across SEC, PHI, DATA, API, ASYNC, RT, FE, TS, TEST, OPS, plus `GEN-000` for anything uncovered. Human-written and meant to be edited.

**The feedback loop** — every comment carries a hidden marker tying it to a rule ID. A weekly job reads how humans responded (👍/👎, reply wording, whether the flagged code changed underneath) and rebuilds each rule's weight as a Beta posterior. Rules that keep getting dismissed go to probation, then mute. Observations decay by half every 90 days, and muted rules are re-tested on ~10% of PRs so a rule that was genuinely fixed earns its way back. The tuning job opens a PR rather than pushing.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- [x] Unit tests pass — 73 tests across scoring, line mapping, marker round-tripping, and outcome inference
- [x] `sync-rules.mjs --check` passes — `review-rules.md` and `rules.json` agree on all 56 rules
- [ ] End-to-end review on a live PR — **blocked until the `OPENROUTER_API_KEY` secret is set**

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated — README gains an "Automated PR Review" section; full design notes in `.github/review/README.md`
- [x] No new npm dependencies — the scripts run on the Node 20 already on `ubuntu-latest`, so there is no install step and no supply-chain surface on a workflow that runs against every PR

## Before this can work

1. **Create an OpenRouter API key** at [openrouter.ai/keys](https://openrouter.ai/keys)
2. **Turn training off for free models** in OpenRouter's privacy settings — this is the step to not skip. Free models are free largely because routing to providers that train on your data is permitted. Diffs of clinical code carry table names, field names, and sometimes fixture data.
3. **Add it** as a repository secret named `OPENROUTER_API_KEY`
4. Optionally pin preferred models as a repository *variable* `OPENROUTER_MODELS` (comma-separated, best first). Unset means the script picks the largest-context free models available at that moment.
5. Consider $10 of credit — the free tier is 50 requests/day, which at 4 requests per PR is about a dozen PRs before the reviewer goes quiet for the day. A one-off top-up raises the cap to 1,000 and is not consumed by `:free` models.

Until the secret exists, the `review` job fails at step 2. The `validate` job in the tuning workflow needs no secret and should pass on this PR.

## Additional Notes

**It never blocks a merge.** The review posts as `COMMENT` and `post-review.mjs` exits zero even on failure. Set `REQUEST_CHANGES_ON_BLOCKER: "1"` to change that.

**Opting out** — add the `skip-review` label to a PR.

**Known limits carried over from the package:** the OpenRouter reviewer only sees the diff, so rules needing repo-wide context (SEC-002, DATA-005, TS-005) will miss more often and should be expected to drift toward probation — that is a limitation of the provider, not the rule. Free models are also weaker at counting new-file line numbers, so a share of findings will land in the summary rather than inline; `post-review.mjs` range-checks every line and demotes rather than failing.

**Rulebook fit:** the rulebook is written for the wider Intelehealth stack, so the SEC/DATA/API sections lean backend (Sequelize, Mongoose, Express) and will rarely fire on a React testbed. The FE, TS, ASYNC, and TEST sections are where the signal will be here. Worth watching which rules go quiet for lack of applicable code versus lack of value — the tuning job cannot tell those apart.
