### PR TITLE
fix(review): gate triggers to main/dev, add on-demand re-review, repair empty reviews

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -54,7 +54,7 @@ marker tying it back to a rule.
 Each comment ends with a hidden marker:
 
 ```html
-<!-- claude-review rule=SEC-001 fid=k3f9q2m conf=0.85 score=0.6 sev=blocker -->
+<!-- ih-tek-review rule=SEC-001 fid=k3f9q2m conf=0.85 score=0.6 sev=blocker -->
 ```
 
 Weekly, `scripts/tune-rules.mjs` walks recent PRs, finds those markers, and

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -3,9 +3,30 @@
 An automated pull request reviewer that applies a written rulebook and gets
 quieter over time about the rules people keep dismissing.
 
+## When it runs
+
+- A PR **into `main` or `dev`** is opened, reopened, or marked ready for review.
+  PRs targeting anything else are not reviewed.
+- Someone adds the **`review-again`** label to such a PR. The label is removed
+  again afterwards so it can be reapplied.
+- Someone with write access comments **`/review`** on it.
+
+Deliberately **not** on `synchronize`. Pushing follow-up commits to an open PR
+does not re-review it, which keeps the free tier from being spent on
+work-in-progress. The cost is real and worth stating plainly: a review goes
+stale the moment the author pushes a fix, so a PR can carry a clean review of
+code that no longer exists. Re-request it with the label or the comment when the
+diff has moved enough to matter.
+
+Two caveats on the comment trigger. GitHub runs `issue_comment` workflows from
+the **default branch**, so `/review` only works once this workflow is merged to
+`main` — the label and the open/reopen triggers work from a PR branch straight
+away. And `/review` is restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because
+without that gate any drive-by commenter could spend the day's request budget.
+
 ## How it works
 
-Every pull request runs three steps:
+Once triggered, a review is three steps:
 
 1. **Prepare** — the workflow computes the diff against the merge base and
    writes it to `.claude-review/pr.diff`.

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -43,8 +43,8 @@ Step 2 is the only provider-specific part. Anything that writes
 and can read the surrounding source rather than only the diff. Swapping
 providers does not touch the rulebook, the gating, or the feedback loop.
 
-The split between step 2 and step 3 is the whole design. Claude decides *what*
-is wrong; the script decides *what gets said*. That keeps the comment cap, the
+The split between step 2 and step 3 is the whole design. Claude decides _what_
+is wrong; the script decides _what gets said_. That keeps the comment cap, the
 confidence thresholds, and the mute list as code rather than as polite requests
 in a prompt, and it means every posted comment carries a machine-readable
 marker tying it back to a rule.
@@ -60,15 +60,15 @@ Each comment ends with a hidden marker:
 Weekly, `scripts/tune-rules.mjs` walks recent PRs, finds those markers, and
 works out how humans actually responded:
 
-| Signal | Outcome |
-| --- | --- |
-| 👎 reaction | rejected |
-| 👍 reaction | accepted |
-| Reply matching a dismissal phrase ("false positive", "by design", …) | rejected |
-| Reply matching an agreement phrase ("good catch", "fixed", …) | accepted |
-| The flagged code changed after the comment (comment went outdated) | accepted |
-| PR closed with no response at all | ignored (weak negative) |
-| PR still open with no response | not scored yet |
+| Signal                                                               | Outcome                 |
+| -------------------------------------------------------------------- | ----------------------- |
+| 👎 reaction                                                          | rejected                |
+| 👍 reaction                                                          | accepted                |
+| Reply matching a dismissal phrase ("false positive", "by design", …) | rejected                |
+| Reply matching an agreement phrase ("good catch", "fixed", …)        | accepted                |
+| The flagged code changed after the comment (comment went outdated)   | accepted                |
+| PR closed with no response at all                                    | ignored (weak negative) |
+| PR still open with no response                                       | not scored yet          |
 
 Each rule carries a Beta posterior over "does this rule produce comments people
 act on". The prior is worth three observations centred on 0.7 — a hand-written
@@ -78,11 +78,11 @@ rule is presumed useful, but not strongly. The posterior mean is the rule's
 A finding is posted when `confidence × weight` clears a per-severity gate:
 
 | Severity | Gate |
-| --- | --- |
-| blocker | 0.30 |
-| major | 0.36 |
-| minor | 0.42 |
-| nit | 0.50 |
+| -------- | ---- |
+| blocker  | 0.30 |
+| major    | 0.36 |
+| minor    | 0.42 |
+| nit      | 0.50 |
 
 Nits have to be more certain than blockers to earn a comment, which is the
 right trade when reviewer attention is the scarce resource.
@@ -114,19 +114,19 @@ are about to go quiet, and why.
 
 ## Files
 
-| Path | What it is |
-| --- | --- |
-| `review-rules.md` | The rulebook. Human-written. Edit this. |
-| `rules.json` | Learned state: weight, status, and evidence per rule. Machine-written. |
-| `feedback-ledger.json` | Every scored comment. The source of truth for weights. |
-| `findings.schema.json` | Contract between the model and the posting script. |
-| `scripts/openrouter-review.mjs` | Produces findings via OpenRouter free models. |
-| `scripts/post-review.mjs` | Gates findings and posts the review. |
-| `scripts/tune-rules.mjs` | The learning loop. |
-| `scripts/sync-rules.mjs` | Keeps the markdown and the JSON in agreement. |
-| `scripts/lib/scoring.mjs` | Pure scoring logic. All of it unit tested. |
-| `scripts/lib/github.mjs` | Dependency-free GitHub REST/GraphQL client. |
-| `scripts/lib/openrouter.mjs` | Model discovery, diff chunking, JSON recovery. |
+| Path                            | What it is                                                             |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `review-rules.md`               | The rulebook. Human-written. Edit this.                                |
+| `rules.json`                    | Learned state: weight, status, and evidence per rule. Machine-written. |
+| `feedback-ledger.json`          | Every scored comment. The source of truth for weights.                 |
+| `findings.schema.json`          | Contract between the model and the posting script.                     |
+| `scripts/openrouter-review.mjs` | Produces findings via OpenRouter free models.                          |
+| `scripts/post-review.mjs`       | Gates findings and posts the review.                                   |
+| `scripts/tune-rules.mjs`        | The learning loop.                                                     |
+| `scripts/sync-rules.mjs`        | Keeps the markdown and the JSON in agreement.                          |
+| `scripts/lib/scoring.mjs`       | Pure scoring logic. All of it unit tested.                             |
+| `scripts/lib/github.mjs`        | Dependency-free GitHub REST/GraphQL client.                            |
+| `scripts/lib/openrouter.mjs`    | Model discovery, diff chunking, JSON recovery.                         |
 
 The scripts have no npm dependencies. They run on the Node 20 already present
 on `ubuntu-latest`, so there is no install step, no lockfile to maintain, and no
@@ -153,7 +153,7 @@ supply-chain surface on a workflow that runs against every PR.
 3. **Add the key** as a repository or organisation secret named
    `OPENROUTER_API_KEY` (Settings → Secrets and variables → Actions).
 
-4. **Optionally pin your preferred models** as a repository *variable* — not a
+4. **Optionally pin your preferred models** as a repository _variable_ — not a
    secret — named `OPENROUTER_MODELS`, comma-separated, best first:
 
    ```

--- a/.github/review/findings.schema.json
+++ b/.github/review/findings.schema.json
@@ -22,7 +22,15 @@
   "$defs": {
     "finding": {
       "type": "object",
-      "required": ["ruleId", "file", "line", "severity", "confidence", "title", "body"],
+      "required": [
+        "ruleId",
+        "file",
+        "line",
+        "severity",
+        "confidence",
+        "title",
+        "body"
+      ],
       "additionalProperties": false,
       "properties": {
         "ruleId": {

--- a/.github/review/review-rules.md
+++ b/.github/review/review-rules.md
@@ -296,6 +296,14 @@ failure points.
 note.** A change that requires the migration, the API, and the client to ship in
 a particular order, with nothing in the PR description saying so.
 
+**OPS-005 · major · Automated safety net removed or weakened.** A CI workflow,
+test, coverage threshold, lint rule, or type check deleted, disabled, or
+loosened, without the PR saying what replaces it. Includes skipping tests
+(`.skip`, `xit`), lowering a coverage floor, adding a broad `eslint-disable` at
+file scope, and removing a required status check. Say which protection is being
+given up and what now catches that class of problem instead. A deliberate
+removal is fine; an unexplained one is how a repo quietly loses its guardrails.
+
 ---
 
 ## GEN — Uncategorised

--- a/.github/review/review-rules.md
+++ b/.github/review/review-rules.md
@@ -43,7 +43,7 @@ how `$ne`/`$gt` operator injection gets in.
 **SEC-002 · blocker · Missing authentication or authorisation on a new route.**
 A new Express route, NestJS controller method, or Socket.IO event handler that
 does not sit behind the project's auth guard/middleware, or that authenticates
-the caller but never checks that the caller is allowed to touch *this* record.
+the caller but never checks that the caller is allowed to touch _this_ record.
 Broken object-level authorisation is the most common real vulnerability in this
 kind of codebase; flag it explicitly rather than assuming a guard exists further
 up.

--- a/.github/review/rules.json
+++ b/.github/review/rules.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "updatedAt": "2026-08-07T00:00:00Z",
   "defaults": {
     "maxCommentsPerPR": 12,
@@ -657,6 +657,18 @@
     "OPS-004": {
       "title": "Backwards-incompatible change with no deploy ordering\nnote",
       "severity": "minor",
+      "weight": 0.7,
+      "state": "active",
+      "stats": {
+        "accepted": 0,
+        "rejected": 0,
+        "ignored": 0
+      },
+      "history": []
+    },
+    "OPS-005": {
+      "title": "Automated safety net removed or weakened",
+      "severity": "major",
       "weight": 0.7,
       "state": "active",
       "stats": {

--- a/.github/review/scripts/lib/github.mjs
+++ b/.github/review/scripts/lib/github.mjs
@@ -8,7 +8,8 @@
  */
 
 const API = process.env.GITHUB_API_URL || 'https://api.github.com';
-const GRAPHQL = process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
+const GRAPHQL =
+  process.env.GITHUB_GRAPHQL_URL || 'https://api.github.com/graphql';
 
 function token() {
   const t = process.env.GITHUB_TOKEN;
@@ -25,7 +26,7 @@ function baseHeaders() {
   };
 }
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 /**
  * REST request with retry on 5xx and secondary-rate-limit responses.
@@ -61,11 +62,17 @@ export async function rest(path, opts = {}) {
       res.status === 429 ||
       (res.status === 403 && /rate limit|abuse|secondary/i.test(text));
 
-    lastErr = new Error(`${method} ${url} -> ${res.status}: ${text.slice(0, 600)}`);
+    lastErr = new Error(
+      `${method} ${url} -> ${res.status}: ${text.slice(0, 600)}`
+    );
     if (!retryable || attempt === retries) throw lastErr;
 
     const retryAfter = Number(res.headers.get('retry-after'));
-    await sleep(Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 2 ** attempt * 1000);
+    await sleep(
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1000
+        : 2 ** attempt * 1000
+    );
   }
   throw lastErr;
 }
@@ -73,7 +80,9 @@ export async function rest(path, opts = {}) {
 /** Follow `Link: rel="next"` until exhausted. */
 export async function restAll(path, { max = 1000 } = {}) {
   const out = [];
-  let url = path.includes('?') ? `${path}&per_page=100` : `${path}?per_page=100`;
+  let url = path.includes('?')
+    ? `${path}&per_page=100`
+    : `${path}?per_page=100`;
   while (url && out.length < max) {
     const { data, link } = await rest(url);
     if (!Array.isArray(data)) break;
@@ -93,7 +102,9 @@ export async function graphql(query, variables = {}) {
   });
   const json = await res.json();
   if (!res.ok || json.errors) {
-    throw new Error(`GraphQL error: ${JSON.stringify(json.errors || json).slice(0, 600)}`);
+    throw new Error(
+      `GraphQL error: ${JSON.stringify(json.errors || json).slice(0, 600)}`
+    );
   }
   return json.data;
 }
@@ -142,7 +153,9 @@ export async function getReviewComments(repo, prNumber) {
 
 /** Reactions on a single PR review comment. */
 export async function getCommentReactions(repo, commentId) {
-  return restAll(`/repos/${repo}/pulls/comments/${commentId}/reactions`, { max: 100 });
+  return restAll(`/repos/${repo}/pulls/comments/${commentId}/reactions`, {
+    max: 100,
+  });
 }
 
 /**
@@ -151,7 +164,11 @@ export async function getCommentReactions(repo, commentId) {
  * @param {number|string} prNumber
  * @param {{commitId:string, body:string, event:'COMMENT'|'REQUEST_CHANGES', comments:Array<object>}} opts
  */
-export async function createReview(repo, prNumber, { commitId, body, event, comments }) {
+export async function createReview(
+  repo,
+  prNumber,
+  { commitId, body, event, comments }
+) {
   const { data } = await rest(`/repos/${repo}/pulls/${prNumber}/reviews`, {
     method: 'POST',
     body: { commit_id: commitId, body, event, comments },

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -186,7 +186,23 @@ export function buildRulesDigest(rules, isExploring = () => false) {
 }
 
 /**
- * Fetch the models that are currently free, largest context first.
+ * Rank candidate models best-first: structured-output support, then context.
+ *
+ * The whole pipeline depends on the reply parsing as strict JSON, and most free
+ * models cannot guarantee that. Ranking on context alone puts a large-context
+ * model that rambles ahead of a smaller one that answers in the required shape,
+ * and the rambling one then wins the chain and returns nothing usable.
+ *
+ * @param {Array<{id:string, context:number, structured:boolean}>} models
+ */
+export function rankModels(models) {
+  return [...models].sort(
+    (a, b) => Number(b.structured) - Number(a.structured) || b.context - a.context,
+  );
+}
+
+/**
+ * Fetch the models that are currently free, best first.
  * @param {string} apiKey
  * @returns {Promise<Array<{id:string, context:number, structured:boolean}>>}
  */
@@ -197,14 +213,15 @@ export async function listFreeModels(apiKey) {
   if (!res.ok) throw new Error(`GET /models -> ${res.status}: ${(await res.text()).slice(0, 300)}`);
   const { data } = await res.json();
 
-  return (data || [])
-    .filter((m) => typeof m.id === 'string' && m.id.endsWith(':free'))
-    .map((m) => ({
-      id: m.id,
-      context: Number(m.context_length) || 0,
-      structured: (m.supported_parameters || []).includes('structured_outputs'),
-    }))
-    .sort((a, b) => b.context - a.context);
+  return rankModels(
+    (data || [])
+      .filter((m) => typeof m.id === 'string' && m.id.endsWith(':free'))
+      .map((m) => ({
+        id: m.id,
+        context: Number(m.context_length) || 0,
+        structured: (m.supported_parameters || []).includes('structured_outputs'),
+      })),
+  );
 }
 
 /**

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -34,7 +34,7 @@ export function splitDiffByFile(diff) {
   if (!diff?.trim()) return [];
   const out = [];
   // Keep the `diff --git` header with its section.
-  const sections = diff.split(/(?=^diff --git )/m).filter((s) => s.trim());
+  const sections = diff.split(/(?=^diff --git )/m).filter(s => s.trim());
   for (const patch of sections) {
     // `diff --git a/path b/path` — take the b-side, which is the new path.
     const m = /^diff --git a\/(.+?) b\/(.+?)$/m.exec(patch);
@@ -68,7 +68,8 @@ export function packChunks(files, { budgetChars, maxChunks }) {
   for (const f of ordered) {
     let patch = f.patch;
     if (patch.length > budgetChars) {
-      patch = patch.slice(0, budgetChars) + '\n... [diff truncated for length] ...\n';
+      patch =
+        patch.slice(0, budgetChars) + '\n... [diff truncated for length] ...\n';
       truncated.push(f.file);
     }
     if (currentSize + patch.length > budgetChars && current.length) {
@@ -82,7 +83,8 @@ export function packChunks(files, { budgetChars, maxChunks }) {
   if (current.length) chunks.push(current);
 
   if (chunks.length > maxChunks) {
-    for (const chunk of chunks.slice(maxChunks)) skipped.push(...chunk.map((f) => f.file));
+    for (const chunk of chunks.slice(maxChunks))
+      skipped.push(...chunk.map(f => f.file));
     return { chunks: chunks.slice(0, maxChunks), skipped, truncated };
   }
   return { chunks, skipped, truncated };
@@ -104,10 +106,12 @@ export function extractJson(text) {
   // Reasoning models emit their scratchpad first.
   let s = text.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
 
-  const attempt = (candidate) => {
+  const attempt = candidate => {
     try {
       const parsed = JSON.parse(candidate);
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed
+        : null;
     } catch {
       return null;
     }
@@ -177,7 +181,9 @@ export function buildRulesDigest(rules, isExploring = () => false) {
       exploring.push(id);
     }
     const note =
-      rule.state === 'probation' ? ' (only report at blocker/major severity)' : '';
+      rule.state === 'probation'
+        ? ' (only report at blocker/major severity)'
+        : '';
     lines.push(`${id} [${rule.severity}] ${rule.title}${note}`);
     included.push(id);
   }
@@ -197,7 +203,8 @@ export function buildRulesDigest(rules, isExploring = () => false) {
  */
 export function rankModels(models) {
   return [...models].sort(
-    (a, b) => Number(b.structured) - Number(a.structured) || b.context - a.context,
+    (a, b) =>
+      Number(b.structured) - Number(a.structured) || b.context - a.context
   );
 }
 
@@ -210,17 +217,22 @@ export async function listFreeModels(apiKey) {
   const res = await fetch(`${BASE}/models`, {
     headers: { authorization: `Bearer ${apiKey}` },
   });
-  if (!res.ok) throw new Error(`GET /models -> ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  if (!res.ok)
+    throw new Error(
+      `GET /models -> ${res.status}: ${(await res.text()).slice(0, 300)}`
+    );
   const { data } = await res.json();
 
   return rankModels(
     (data || [])
-      .filter((m) => typeof m.id === 'string' && m.id.endsWith(':free'))
-      .map((m) => ({
+      .filter(m => typeof m.id === 'string' && m.id.endsWith(':free'))
+      .map(m => ({
         id: m.id,
         context: Number(m.context_length) || 0,
-        structured: (m.supported_parameters || []).includes('structured_outputs'),
-      })),
+        structured: (m.supported_parameters || []).includes(
+          'structured_outputs'
+        ),
+      }))
   );
 }
 
@@ -241,15 +253,19 @@ export const MAX_FALLBACK_MODELS = 3;
  * @param {string[]} preferred
  * @param {number} limit
  */
-export function chooseModels(available, preferred = [], limit = MAX_FALLBACK_MODELS) {
-  const byId = new Map(available.map((m) => [m.id, m]));
+export function chooseModels(
+  available,
+  preferred = [],
+  limit = MAX_FALLBACK_MODELS
+) {
+  const byId = new Map(available.map(m => [m.id, m]));
   const chain = [];
   for (const id of preferred) {
     if (byId.has(id)) chain.push(byId.get(id));
   }
   for (const m of available) {
     if (chain.length >= limit) break;
-    if (!chain.some((c) => c.id === m.id)) chain.push(m);
+    if (!chain.some(c => c.id === m.id)) chain.push(m);
   }
   return chain.slice(0, limit);
 }
@@ -311,16 +327,22 @@ export async function complete(opts) {
       const text = await res.text();
       if (!res.ok) {
         const retryable = res.status === 429 || res.status >= 500;
-        lastErr = new Error(`POST /chat/completions -> ${res.status}: ${text.slice(0, 400)}`);
+        lastErr = new Error(
+          `POST /chat/completions -> ${res.status}: ${text.slice(0, 400)}`
+        );
         if (!retryable || attempt === retries) throw lastErr;
-        const wait = Number(res.headers.get('retry-after')) * 1000 || 2 ** attempt * 4000;
-        await new Promise((r) => setTimeout(r, wait));
+        const wait =
+          Number(res.headers.get('retry-after')) * 1000 || 2 ** attempt * 4000;
+        await new Promise(r => setTimeout(r, wait));
         continue;
       }
 
       const json = JSON.parse(text);
       // OpenRouter can return a 200 whose body carries a provider error.
-      if (json.error) throw new Error(`provider error: ${JSON.stringify(json.error).slice(0, 300)}`);
+      if (json.error)
+        throw new Error(
+          `provider error: ${JSON.stringify(json.error).slice(0, 300)}`
+        );
       return {
         text: json.choices?.[0]?.message?.content ?? '',
         model: json.model || chain[0],
@@ -329,7 +351,7 @@ export async function complete(opts) {
     } catch (err) {
       lastErr = err;
       if (attempt === retries) throw lastErr;
-      await new Promise((r) => setTimeout(r, 2 ** attempt * 2000));
+      await new Promise(r => setTimeout(r, 2 ** attempt * 2000));
     }
   }
   throw lastErr;
@@ -338,7 +360,9 @@ export async function complete(opts) {
 /** Remaining free-tier allowance, for logging. Never throws. */
 export async function keyStatus(apiKey) {
   try {
-    const res = await fetch(`${BASE}/key`, { headers: { authorization: `Bearer ${apiKey}` } });
+    const res = await fetch(`${BASE}/key`, {
+      headers: { authorization: `Bearer ${apiKey}` },
+    });
     if (!res.ok) return null;
     const { data } = await res.json();
     return data || null;

--- a/.github/review/scripts/lib/scoring.mjs
+++ b/.github/review/scripts/lib/scoring.mjs
@@ -73,7 +73,8 @@ export function evidenceCount(stats) {
  */
 export function computeState(weight, n) {
   if (n >= MUTE_MIN_EVIDENCE && weight < MUTE_WEIGHT) return 'muted';
-  if (n >= PROBATION_MIN_EVIDENCE && weight < PROBATION_WEIGHT) return 'probation';
+  if (n >= PROBATION_MIN_EVIDENCE && weight < PROBATION_WEIGHT)
+    return 'probation';
   return 'active';
 }
 
@@ -162,8 +163,14 @@ export function gateFindings(findings, rules, opts) {
       }
     }
 
-    if (rule.state === 'probation' && SEVERITY_ORDER[f.severity] > SEVERITY_ORDER.major) {
-      dropped.push({ finding: f, reason: 'rule on probation; only blocker/major posted' });
+    if (
+      rule.state === 'probation' &&
+      SEVERITY_ORDER[f.severity] > SEVERITY_ORDER.major
+    ) {
+      dropped.push({
+        finding: f,
+        reason: 'rule on probation; only blocker/major posted',
+      });
       continue;
     }
 
@@ -190,7 +197,7 @@ export function gateFindings(findings, rules, opts) {
   kept.sort(
     (a, b) =>
       (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9) ||
-      b._score - a._score,
+      b._score - a._score
   );
 
   const overflow = kept.slice(maxComments);
@@ -245,13 +252,18 @@ export function rebuildRules(rules, outcomes, now) {
     const rule = next[o.ruleId];
     if (!rule) continue;
     const bucket =
-      o.outcome === 'accepted' ? 'accepted' : o.outcome === 'rejected' ? 'rejected' : 'ignored';
+      o.outcome === 'accepted'
+        ? 'accepted'
+        : o.outcome === 'rejected'
+          ? 'rejected'
+          : 'ignored';
     rule.stats[bucket] += decayFactor(o.at, now);
   }
 
   const changes = [];
   for (const [ruleId, rule] of Object.entries(next)) {
-    for (const k of ['accepted', 'rejected', 'ignored']) rule.stats[k] = round3(rule.stats[k]);
+    for (const k of ['accepted', 'rejected', 'ignored'])
+      rule.stats[k] = round3(rule.stats[k]);
 
     const before = { weight: rules[ruleId].weight, state: rules[ruleId].state };
     rule.weight = computeWeight(rule.stats);

--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -49,7 +49,7 @@ const MAX_REQUESTS = Number(process.env.MAX_REQUESTS) || 4;
 const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 4000;
 const PREFERRED = (process.env.OPENROUTER_MODELS || '')
   .split(',')
-  .map((s) => s.trim())
+  .map(s => s.trim())
   .filter(Boolean);
 
 /** Free tier allows 20 requests/minute. Stay comfortably under it. */
@@ -61,7 +61,7 @@ const REQUEST_SPACING_MS = 3500;
  */
 const MAX_CHUNK_CHARS = 40_000;
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 const SYSTEM_PROMPT = `You are a precise code reviewer. You review only the changed lines in a git diff.
 
@@ -72,8 +72,8 @@ You are strict about false positives. A short review with two real problems is f
 Never report: formatting or style that a linter handles, naming preferences, missing comments, speculative refactors, praise, or restatements of what the code does.`;
 
 function userPrompt({ digest, chunk, chunkIndex, chunkCount }) {
-  const files = chunk.map((f) => f.file).join('\n');
-  const diff = chunk.map((f) => f.patch).join('\n');
+  const files = chunk.map(f => f.file).join('\n');
+  const diff = chunk.map(f => f.patch).join('\n');
 
   return `Review this pull request diff against the rules below.
 
@@ -127,10 +127,14 @@ function sanitise(findings, chunkFiles, validRuleIds) {
   for (const f of Array.isArray(findings) ? findings : []) {
     if (!f || typeof f !== 'object') continue;
 
-    const ruleId = String(f.ruleId || '').toUpperCase().trim();
+    const ruleId = String(f.ruleId || '')
+      .toUpperCase()
+      .trim();
     const line = Number.parseInt(f.line, 10);
     const endLine = Number.parseInt(f.endLine, 10);
-    const severity = String(f.severity || '').toLowerCase().trim();
+    const severity = String(f.severity || '')
+      .toLowerCase()
+      .trim();
     const confidence = Number(f.confidence);
 
     if (!validRuleIds.has(ruleId)) {
@@ -167,7 +171,9 @@ function sanitise(findings, chunkFiles, validRuleIds) {
       confidence: Math.min(1, Math.max(0, confidence)),
       title: String(f.title).slice(0, 120),
       body: String(f.body).slice(0, 4000),
-      ...(f.suggestion ? { suggestion: String(f.suggestion).slice(0, 2000) } : {}),
+      ...(f.suggestion
+        ? { suggestion: String(f.suggestion).slice(0, 2000) }
+        : {}),
     });
   }
   return { findings: out, rejected };
@@ -183,30 +189,39 @@ async function main() {
 
   if (!API_KEY) {
     console.error('OPENROUTER_API_KEY is not set.');
-    writeFindings({ summary: 'Review skipped: no OpenRouter API key configured.', findings: [] });
+    writeFindings({
+      summary: 'Review skipped: no OpenRouter API key configured.',
+      findings: [],
+    });
     return;
   }
   if (!existsSync(DIFF_PATH)) {
     console.error(`${DIFF_PATH} is missing.`);
-    writeFindings({ summary: 'Review skipped: no diff was produced.', findings: [] });
+    writeFindings({
+      summary: 'Review skipped: no diff was produced.',
+      findings: [],
+    });
     return;
   }
 
   const diff = readFileSync(DIFF_PATH, 'utf8');
   if (!diff.trim()) {
-    writeFindings({ summary: 'No reviewable changes in this pull request.', findings: [] });
+    writeFindings({
+      summary: 'No reviewable changes in this pull request.',
+      findings: [],
+    });
     return;
   }
 
   const book = JSON.parse(readFileSync(RULES_PATH, 'utf8'));
   const explorationPercent = book.defaults?.explorationPercent ?? 10;
-  const { digest, included, exploring } = buildRulesDigest(book.rules, (ruleId) =>
-    isExplorationSlot(ruleId, PR_NUMBER, explorationPercent),
+  const { digest, included, exploring } = buildRulesDigest(book.rules, ruleId =>
+    isExplorationSlot(ruleId, PR_NUMBER, explorationPercent)
   );
   const validRuleIds = new Set(included);
   console.log(
     `Rulebook v${book.version}: ${included.length} rule(s) in play` +
-      (exploring.length ? `, re-testing muted ${exploring.join(', ')}` : ''),
+      (exploring.length ? `, re-testing muted ${exploring.join(', ')}` : '')
   );
 
   // --- pick models --------------------------------------------------------
@@ -215,39 +230,58 @@ async function main() {
     available = await listFreeModels(API_KEY);
   } catch (err) {
     console.error(`Could not list models: ${err.message}`);
-    writeFindings({ summary: `Review skipped: OpenRouter unreachable (${err.message}).`, findings: [] });
+    writeFindings({
+      summary: `Review skipped: OpenRouter unreachable (${err.message}).`,
+      findings: [],
+    });
     return;
   }
   if (available.length === 0) {
-    writeFindings({ summary: 'Review skipped: no free models are currently available.', findings: [] });
+    writeFindings({
+      summary: 'Review skipped: no free models are currently available.',
+      findings: [],
+    });
     return;
   }
 
   const chain = chooseModels(available, PREFERRED, MAX_FALLBACK_MODELS);
-  const minContext = Math.min(...chain.map((m) => m.context));
-  const jsonMode = chain.every((m) => m.structured);
-  console.log(`Model chain: ${chain.map((m) => m.id).join(' -> ')}`);
-  console.log(`Smallest context in chain: ${minContext} tokens. JSON mode: ${jsonMode}.`);
+  const minContext = Math.min(...chain.map(m => m.context));
+  const jsonMode = chain.every(m => m.structured);
+  console.log(`Model chain: ${chain.map(m => m.id).join(' -> ')}`);
+  console.log(
+    `Smallest context in chain: ${minContext} tokens. JSON mode: ${jsonMode}.`
+  );
 
   const status = await keyStatus(API_KEY);
   if (status) {
     console.log(
       `Key usage: ${status.usage ?? '?'} / limit ${status.limit ?? 'none'}` +
-        (status.rate_limit ? ` (${status.rate_limit.requests}/${status.rate_limit.interval})` : ''),
+        (status.rate_limit
+          ? ` (${status.rate_limit.requests}/${status.rate_limit.interval})`
+          : '')
     );
   }
 
   // --- chunk the diff -----------------------------------------------------
   const overheadTokens = estimateTokens(SYSTEM_PROMPT + digest) + 800;
-  const budgetTokens = Math.max(2000, minContext - MAX_OUTPUT_TOKENS - overheadTokens);
-  const budgetChars = Math.min(MAX_CHUNK_CHARS, Math.floor(budgetTokens * CHARS_PER_TOKEN));
+  const budgetTokens = Math.max(
+    2000,
+    minContext - MAX_OUTPUT_TOKENS - overheadTokens
+  );
+  const budgetChars = Math.min(
+    MAX_CHUNK_CHARS,
+    Math.floor(budgetTokens * CHARS_PER_TOKEN)
+  );
 
   const files = splitDiffByFile(diff);
-  const { chunks, skipped, truncated } = packChunks(files, { budgetChars, maxChunks: MAX_REQUESTS });
+  const { chunks, skipped, truncated } = packChunks(files, {
+    budgetChars,
+    maxChunks: MAX_REQUESTS,
+  });
   console.log(
     `${files.length} file(s) -> ${chunks.length} request(s) at ${budgetChars} chars each.` +
       (truncated.length ? ` Truncated: ${truncated.join(', ')}.` : '') +
-      (skipped.length ? ` Skipped (request cap): ${skipped.join(', ')}.` : ''),
+      (skipped.length ? ` Skipped (request cap): ${skipped.join(', ')}.` : '')
   );
 
   // --- review -------------------------------------------------------------
@@ -259,16 +293,21 @@ async function main() {
 
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i];
-    const chunkFiles = chunk.map((f) => f.file);
+    const chunkFiles = chunk.map(f => f.file);
     if (i > 0) await sleep(REQUEST_SPACING_MS);
 
     let result;
     try {
       result = await complete({
         apiKey: API_KEY,
-        models: chain.map((m) => m.id),
+        models: chain.map(m => m.id),
         system: SYSTEM_PROMPT,
-        user: userPrompt({ digest, chunk, chunkIndex: i, chunkCount: chunks.length }),
+        user: userPrompt({
+          digest,
+          chunk,
+          chunkIndex: i,
+          chunkCount: chunks.length,
+        }),
         maxTokens: MAX_OUTPUT_TOKENS,
         jsonMode,
         title: `PR Review #${PR_NUMBER}`,
@@ -284,12 +323,14 @@ async function main() {
 
     // Free models sometimes narrate before the JSON. One cheap repair attempt.
     if (!parsed) {
-      console.log(`Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`);
+      console.log(
+        `Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`
+      );
       await sleep(REQUEST_SPACING_MS);
       try {
         const repair = await complete({
           apiKey: API_KEY,
-          models: chain.map((m) => m.id),
+          models: chain.map(m => m.id),
           system: SYSTEM_PROMPT,
           user:
             'Your previous reply was not valid JSON. Return the same content as a single JSON ' +
@@ -306,12 +347,21 @@ async function main() {
     }
 
     if (!parsed) {
-      debug.push({ batch: i + 1, files: chunkFiles, model: result.model, unparseable: result.text.slice(0, 1200) });
+      debug.push({
+        batch: i + 1,
+        files: chunkFiles,
+        model: result.model,
+        unparseable: result.text.slice(0, 1200),
+      });
       failures++;
       continue;
     }
 
-    const { findings, rejected } = sanitise(parsed.findings, chunkFiles, validRuleIds);
+    const { findings, rejected } = sanitise(
+      parsed.findings,
+      chunkFiles,
+      validRuleIds
+    );
     for (const f of findings) {
       const key = `${f.ruleId}|${f.file}|${f.line}`;
       if (seen.has(key)) continue;
@@ -322,7 +372,7 @@ async function main() {
 
     console.log(
       `Batch ${i + 1}/${chunks.length} via ${result.model}: ` +
-        `${findings.length} finding(s) kept, ${rejected.length} rejected.`,
+        `${findings.length} finding(s) kept, ${rejected.length} rejected.`
     );
     debug.push({
       batch: i + 1,
@@ -336,18 +386,23 @@ async function main() {
 
   // --- assemble -----------------------------------------------------------
   const notes = [];
-  if (truncated.length) notes.push(`Large diffs truncated in: ${truncated.join(', ')}.`);
+  if (truncated.length)
+    notes.push(`Large diffs truncated in: ${truncated.join(', ')}.`);
   if (skipped.length) {
-    notes.push(`Not reviewed — hit the ${MAX_REQUESTS}-request budget: ${skipped.join(', ')}.`);
+    notes.push(
+      `Not reviewed — hit the ${MAX_REQUESTS}-request budget: ${skipped.join(', ')}.`
+    );
   }
   if (failures === chunks.length) {
     notes.push(
       `**Nothing was reviewed.** All ${chunks.length} batch(es) failed, so an absence of ` +
         `findings below means the diff was never read — not that it is clean. ` +
-        `See the workflow log for the provider error.`,
+        `See the workflow log for the provider error.`
     );
   } else if (failures) {
-    notes.push(`${failures} of ${chunks.length} batch(es) failed and were skipped.`);
+    notes.push(
+      `${failures} of ${chunks.length} batch(es) failed and were skipped.`
+    );
   }
 
   const summary =
@@ -355,11 +410,14 @@ async function main() {
     'No reviewable findings were produced.';
 
   writeFindings({ summary, findings: all });
-  writeFileSync(DEBUG_PATH, JSON.stringify({ chain: chain.map((m) => m.id), debug }, null, 2));
+  writeFileSync(
+    DEBUG_PATH,
+    JSON.stringify({ chain: chain.map(m => m.id), debug }, null, 2)
+  );
   console.log(`Wrote ${all.length} finding(s) to ${FINDINGS_PATH}.`);
 }
 
-main().catch((err) => {
+main().catch(err => {
   console.error(`openrouter-review failed: ${err.stack || err.message}`);
   try {
     writeFindings({ summary: `Review failed: ${err.message}`, findings: [] });

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -32,7 +32,7 @@ import { gateFindings, SEVERITY_ORDER } from './lib/scoring.mjs';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const RULES_PATH = join(HERE, '..', 'rules.json');
 const FINDINGS_PATH = '.claude-review/findings.json';
-const MARKER = 'claude-review';
+const MARKER = 'ih-tek-review';
 
 const REPO = process.env.REPO;
 const PR_NUMBER = process.env.PR_NUMBER;
@@ -109,7 +109,7 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
   const counts = { blocker: 0, major: 0, minor: 0, nit: 0 };
   for (const f of kept) counts[f.severity]++;
 
-  const lines = ['## Automated PR review', ''];
+  const lines = ['## IH Tek review', ''];
   lines.push(summary || '_No summary was produced._', '');
 
   if (kept.length === 0) {

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -109,7 +109,7 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
   const counts = { blocker: 0, major: 0, minor: 0, nit: 0 };
   for (const f of kept) counts[f.severity]++;
 
-  const lines = ['## Claude review', ''];
+  const lines = ['## Automated PR review', ''];
   lines.push(summary || '_No summary was produced._', '');
 
   if (kept.length === 0) {

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -38,7 +38,8 @@ const REPO = process.env.REPO;
 const PR_NUMBER = process.env.PR_NUMBER;
 const HEAD_SHA = process.env.HEAD_SHA;
 const DIFF_TRUNCATED = process.env.DIFF_TRUNCATED === 'true';
-const REQUEST_CHANGES_ON_BLOCKER = process.env.REQUEST_CHANGES_ON_BLOCKER === '1';
+const REQUEST_CHANGES_ON_BLOCKER =
+  process.env.REQUEST_CHANGES_ON_BLOCKER === '1';
 
 const SEVERITY_LABEL = {
   blocker: '🔴 Blocker',
@@ -49,41 +50,57 @@ const SEVERITY_LABEL = {
 
 /** Validate a single finding. Returns an error string, or null if it is fine. */
 function validateFinding(f, i) {
-  if (typeof f !== 'object' || f === null) return `finding[${i}] is not an object`;
-  if (!/^[A-Z]+-\d+$/.test(f.ruleId || '')) return `finding[${i}] has a bad ruleId`;
+  if (typeof f !== 'object' || f === null)
+    return `finding[${i}] is not an object`;
+  if (!/^[A-Z]+-\d+$/.test(f.ruleId || ''))
+    return `finding[${i}] has a bad ruleId`;
   if (typeof f.file !== 'string' || !f.file) return `finding[${i}] has no file`;
-  if (!Number.isInteger(f.line) || f.line < 1) return `finding[${i}] has a bad line`;
-  if (!(f.severity in SEVERITY_ORDER)) return `finding[${i}] has a bad severity`;
+  if (!Number.isInteger(f.line) || f.line < 1)
+    return `finding[${i}] has a bad line`;
+  if (!(f.severity in SEVERITY_ORDER))
+    return `finding[${i}] has a bad severity`;
   if (typeof f.confidence !== 'number' || f.confidence < 0 || f.confidence > 1)
     return `finding[${i}] has a bad confidence`;
-  if (typeof f.title !== 'string' || !f.title) return `finding[${i}] has no title`;
+  if (typeof f.title !== 'string' || !f.title)
+    return `finding[${i}] has no title`;
   if (typeof f.body !== 'string' || !f.body) return `finding[${i}] has no body`;
   return null;
 }
 
 function commentBody(f, rule) {
-  const parts = [`**${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** — ${f.title}`, '', f.body];
+  const parts = [
+    `**${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** — ${f.title}`,
+    '',
+    f.body,
+  ];
 
   if (f.suggestion) {
-    parts.push('', '```suggestion', f.suggestion.replace(/^```\w*\n?|```$/g, ''), '```');
+    parts.push(
+      '',
+      '```suggestion',
+      f.suggestion.replace(/^```\w*\n?|```$/g, ''),
+      '```'
+    );
   }
 
   const notes = [];
   if (f._exploring) {
     notes.push(
       'This rule is currently muted because past comments from it were dismissed. ' +
-        'It is being re-tested on this PR — your reaction decides whether it comes back.',
+        'It is being re-tested on this PR — your reaction decides whether it comes back.'
     );
   }
   if (rule.state === 'probation') {
-    notes.push('This rule is on probation; feedback on it is weighted heavily.');
+    notes.push(
+      'This rule is on probation; feedback on it is weighted heavily.'
+    );
   }
   if (notes.length) parts.push('', `> ${notes.join(' ')}`);
 
   parts.push(
     '',
     '<sub>👍 if this was useful, 👎 if it was not — the reviewer tunes itself from these reactions.</sub>',
-    `<!-- ${MARKER} rule=${f.ruleId} fid=${f._fid} conf=${f.confidence} score=${f._score} sev=${f.severity}${f._exploring ? ' explore=1' : ''} -->`,
+    `<!-- ${MARKER} rule=${f.ruleId} fid=${f._fid} conf=${f.confidence} score=${f._score} sev=${f.severity}${f._exploring ? ' explore=1' : ''} -->`
   );
   return parts.join('\n');
 }
@@ -99,7 +116,9 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
     // A clean verdict is only honest when something was actually read. The
     // generator says so in the summary when it reviewed nothing at all.
     if (!/nothing was reviewed/i.test(summary || '')) {
-      lines.push('No findings above the confidence threshold. Nothing to flag.');
+      lines.push(
+        'No findings above the confidence threshold. Nothing to flag.'
+      );
     }
   } else {
     lines.push(
@@ -107,7 +126,7 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
         Object.entries(counts)
           .filter(([, n]) => n > 0)
           .map(([sev, n]) => `${SEVERITY_LABEL[sev]} ${n}`)
-          .join(' · '),
+          .join(' · ')
     );
   }
 
@@ -117,39 +136,51 @@ function summaryBody({ summary, kept, dropped, outOfDiff, invalid, rules }) {
       '### Findings outside the diff',
       '',
       'These could not be attached to a line this PR changed:',
-      '',
+      ''
     );
     for (const f of outOfDiff) {
       lines.push(`- **${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}`);
     }
   }
 
-  const noise = dropped.filter((d) => !/already posted/.test(d.reason));
+  const noise = dropped.filter(d => !/already posted/.test(d.reason));
   if (noise.length) {
     lines.push(
       '',
-      '<details><summary>' + noise.length + ' finding(s) suppressed by the feedback loop</summary>',
-      '',
+      '<details><summary>' +
+        noise.length +
+        ' finding(s) suppressed by the feedback loop</summary>',
+      ''
     );
     for (const d of noise) {
-      lines.push(`- \`${d.finding.ruleId}\` ${d.finding.file}:${d.finding.line} — ${d.reason}`);
+      lines.push(
+        `- \`${d.finding.ruleId}\` ${d.finding.file}:${d.finding.line} — ${d.reason}`
+      );
     }
     lines.push('', '</details>');
   }
 
   if (invalid.length) {
-    lines.push('', `<sub>${invalid.length} malformed finding(s) discarded: ${invalid.join('; ')}</sub>`);
+    lines.push(
+      '',
+      `<sub>${invalid.length} malformed finding(s) discarded: ${invalid.join('; ')}</sub>`
+    );
   }
   if (DIFF_TRUNCATED) {
-    lines.push('', '<sub>⚠️ The diff was truncated for size — later files were not reviewed.</sub>');
+    lines.push(
+      '',
+      '<sub>⚠️ The diff was truncated for size — later files were not reviewed.</sub>'
+    );
   }
 
-  const muted = Object.entries(rules).filter(([, r]) => r.state === 'muted').length;
+  const muted = Object.entries(rules).filter(
+    ([, r]) => r.state === 'muted'
+  ).length;
   lines.push(
     '',
     `<sub>Rulebook v${rules._version ?? '?'} · ${Object.keys(rules).length - 1} rules · ${muted} muted. ` +
       'See `.github/review/review-rules.md`. React 👍/👎 on any comment to tune the reviewer.</sub>',
-    `<!-- ${MARKER} summary -->`,
+    `<!-- ${MARKER} summary -->`
   );
   return lines.join('\n');
 }
@@ -161,7 +192,9 @@ async function main() {
   }
 
   if (!existsSync(FINDINGS_PATH)) {
-    console.log('No findings.json was produced — the review step likely failed. Nothing to post.');
+    console.log(
+      'No findings.json was produced — the review step likely failed. Nothing to post.'
+    );
     return;
   }
 
@@ -185,13 +218,17 @@ async function main() {
     if (err) invalid.push(err);
     else valid.push(f);
   });
-  console.log(`Parsed ${valid.length} valid finding(s), ${invalid.length} discarded.`);
+  console.log(
+    `Parsed ${valid.length} valid finding(s), ${invalid.length} discarded.`
+  );
 
   // --- idempotency: what did earlier runs already say? --------------------
   const existing = await getReviewComments(REPO, PR_NUMBER);
   const alreadyPosted = new Set();
   for (const c of existing) {
-    const m = new RegExp(`<!-- ${MARKER} .*?fid=([a-z0-9]+)`).exec(c.body || '');
+    const m = new RegExp(`<!-- ${MARKER} .*?fid=([a-z0-9]+)`).exec(
+      c.body || ''
+    );
     if (m) alreadyPosted.add(m[1]);
   }
   console.log(`${alreadyPosted.size} finding(s) already posted on this PR.`);
@@ -203,12 +240,15 @@ async function main() {
     explorationPercent: book.defaults?.explorationPercent ?? 10,
     alreadyPosted,
   });
-  console.log(`${kept.length} finding(s) passed the gate, ${dropped.length} dropped.`);
+  console.log(
+    `${kept.length} finding(s) passed the gate, ${dropped.length} dropped.`
+  );
 
   // --- map to lines GitHub will accept ------------------------------------
   const files = await getPullFiles(REPO, PR_NUMBER);
   const lineIndex = new Map();
-  for (const file of files) lineIndex.set(file.filename, commentableLines(file.patch));
+  for (const file of files)
+    lineIndex.set(file.filename, commentableLines(file.patch));
 
   const inline = [];
   const outOfDiff = [];
@@ -225,7 +265,11 @@ async function main() {
       body: commentBody(f, rules[f.ruleId]),
     };
     // Multi-line comments need start_line to also be in the diff.
-    if (Number.isInteger(f.endLine) && f.endLine > f.line && allowed.has(f.endLine)) {
+    if (
+      Number.isInteger(f.endLine) &&
+      f.endLine > f.line &&
+      allowed.has(f.endLine)
+    ) {
       comment.start_line = f.line;
       comment.start_side = 'RIGHT';
       comment.line = f.endLine;
@@ -233,10 +277,12 @@ async function main() {
     inline.push(comment);
   }
   if (outOfDiff.length) {
-    console.log(`${outOfDiff.length} finding(s) fell outside the diff; moved into the summary.`);
+    console.log(
+      `${outOfDiff.length} finding(s) fell outside the diff; moved into the summary.`
+    );
   }
 
-  const hasBlocker = kept.some((f) => f.severity === 'blocker');
+  const hasBlocker = kept.some(f => f.severity === 'blocker');
   const body = summaryBody({
     summary: payload.summary,
     kept,
@@ -252,28 +298,36 @@ async function main() {
     return;
   }
 
-  writeFileSync('.claude-review/posted.json', JSON.stringify({ inline, outOfDiff, dropped }, null, 2));
+  writeFileSync(
+    '.claude-review/posted.json',
+    JSON.stringify({ inline, outOfDiff, dropped }, null, 2)
+  );
 
   try {
     await createReview(REPO, PR_NUMBER, {
       commitId: HEAD_SHA,
       body,
-      event: hasBlocker && REQUEST_CHANGES_ON_BLOCKER ? 'REQUEST_CHANGES' : 'COMMENT',
+      event:
+        hasBlocker && REQUEST_CHANGES_ON_BLOCKER
+          ? 'REQUEST_CHANGES'
+          : 'COMMENT',
       comments: inline,
     });
     console.log(`Posted a review with ${inline.length} inline comment(s).`);
   } catch (err) {
     // The review API is all-or-nothing. Rather than lose the whole review to
     // one bad line reference, fall back to a single summary comment.
-    console.error(`Inline review failed, falling back to a summary comment: ${err.message}`);
+    console.error(
+      `Inline review failed, falling back to a summary comment: ${err.message}`
+    );
     const fallback = [
       body,
       '',
       '### Findings',
       '',
       ...kept.map(
-        (f) =>
-          `- **${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}\n\n  ${f.body.replace(/\n/g, '\n  ')}`,
+        f =>
+          `- **${SEVERITY_LABEL[f.severity]} · ${f.ruleId}** \`${f.file}:${f.line}\` — ${f.title}\n\n  ${f.body.replace(/\n/g, '\n  ')}`
       ),
     ].join('\n');
     try {
@@ -285,7 +339,7 @@ async function main() {
   }
 }
 
-main().catch((err) => {
+main().catch(err => {
   // Log loudly, exit clean. The reviewer is advisory; it must never be the
   // reason a pull request cannot merge.
   console.error(`post-review failed: ${err.stack || err.message}`);

--- a/.github/review/scripts/sync-rules.mjs
+++ b/.github/review/scripts/sync-rules.mjs
@@ -14,7 +14,14 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { computeState, computeWeight, evidenceCount, PRIOR_ALPHA, PRIOR_BETA, round3 } from './lib/scoring.mjs';
+import {
+  computeState,
+  computeWeight,
+  evidenceCount,
+  PRIOR_ALPHA,
+  PRIOR_BETA,
+  round3,
+} from './lib/scoring.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MD_PATH = join(HERE, '..', 'review-rules.md');
@@ -24,13 +31,15 @@ const SEED_WEIGHT = round3(PRIOR_ALPHA / (PRIOR_ALPHA + PRIOR_BETA)); // 0.7
 
 /** Extract `**ID · severity · Title.**` headings from the rulebook. */
 export function parseRulebook(markdown) {
-  const re = /^\*\*([A-Z]+-\d+)\s*[·.]\s*(blocker|major|minor|nit)\s*[·.]\s*([^*]+?)\*\*/gm;
+  const re =
+    /^\*\*([A-Z]+-\d+)\s*[·.]\s*(blocker|major|minor|nit)\s*[·.]\s*([^*]+?)\*\*/gm;
   const rules = {};
   const seen = new Set();
   let m;
   while ((m = re.exec(markdown)) !== null) {
     const [, id, severity, title] = m;
-    if (seen.has(id)) throw new Error(`Duplicate rule id in review-rules.md: ${id}`);
+    if (seen.has(id))
+      throw new Error(`Duplicate rule id in review-rules.md: ${id}`);
     seen.add(id);
     rules[id] = { title: title.trim().replace(/\.$/, ''), severity };
   }
@@ -85,11 +94,20 @@ function reconcile(md, book) {
     const weight = computeWeight(stats);
     const state = computeState(weight, evidenceCount(stats));
 
-    if (existing.title !== meta.title) problems.push(`${id}: title differs from review-rules.md`);
-    if (existing.severity !== meta.severity) problems.push(`${id}: severity differs from review-rules.md`);
-    if (existing.weight !== weight) problems.push(`${id}: weight ${existing.weight} does not match stats (${weight})`);
-    if (existing.state !== state) problems.push(`${id}: state ${existing.state} does not match weight (${state})`);
-    if (book.retired[id]) problems.push(`${id}: listed as retired but present in review-rules.md`);
+    if (existing.title !== meta.title)
+      problems.push(`${id}: title differs from review-rules.md`);
+    if (existing.severity !== meta.severity)
+      problems.push(`${id}: severity differs from review-rules.md`);
+    if (existing.weight !== weight)
+      problems.push(
+        `${id}: weight ${existing.weight} does not match stats (${weight})`
+      );
+    if (existing.state !== state)
+      problems.push(
+        `${id}: state ${existing.state} does not match weight (${state})`
+      );
+    if (book.retired[id])
+      problems.push(`${id}: listed as retired but present in review-rules.md`);
 
     rules[id] = {
       title: meta.title,
@@ -104,7 +122,9 @@ function reconcile(md, book) {
   const retired = { ...book.retired };
   for (const id of Object.keys(book.rules)) {
     if (md[id]) continue;
-    problems.push(`${id} is in rules.json but not in review-rules.md (will be retired)`);
+    problems.push(
+      `${id} is in rules.json but not in review-rules.md (will be retired)`
+    );
     retired[id] = { ...book.rules[id], retired: true };
   }
   for (const id of Object.keys(md)) delete retired[id];
@@ -117,7 +137,9 @@ function main() {
   const { md, book } = load();
   const count = Object.keys(md).length;
   if (count === 0) {
-    console.error('No rules parsed from review-rules.md — check the heading format.');
+    console.error(
+      'No rules parsed from review-rules.md — check the heading format.'
+    );
     process.exit(1);
   }
 
@@ -125,9 +147,13 @@ function main() {
 
   if (mode === 'check') {
     if (problems.length) {
-      console.error(`rules.json is out of sync with review-rules.md (${problems.length} problem(s)):`);
+      console.error(
+        `rules.json is out of sync with review-rules.md (${problems.length} problem(s)):`
+      );
       for (const p of problems) console.error(`  - ${p}`);
-      console.error('\nRun: node .github/review/scripts/sync-rules.mjs --write');
+      console.error(
+        '\nRun: node .github/review/scripts/sync-rules.mjs --write'
+      );
       process.exit(1);
     }
     console.log(`rules.json is in sync (${count} rules).`);
@@ -142,7 +168,9 @@ function main() {
     retired,
   };
   writeFileSync(JSON_PATH, JSON.stringify(next, null, 2) + '\n');
-  console.log(`Wrote rules.json: ${count} active rules, ${Object.keys(retired).length} retired.`);
+  console.log(
+    `Wrote rules.json: ${count} active rules, ${Object.keys(retired).length} retired.`
+  );
   for (const p of problems) console.log(`  - ${p}`);
 }
 

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -22,6 +22,7 @@ import {
   chooseModels,
   extractJson,
   packChunks,
+  rankModels,
   splitDiffByFile,
 } from '../lib/openrouter.mjs';
 
@@ -202,6 +203,35 @@ test('with no preference the largest context comes first', () => {
 
 test('the chain never exceeds the requested length', () => {
   assert.equal(chooseModels(AVAILABLE, [], 2).length, 2);
+});
+
+test('a model that guarantees JSON outranks a bigger one that does not', () => {
+  // The regression this locks in: ranking on context alone put a 262k model
+  // with no structured-output support ahead of a 128k model that had it, and
+  // the big one returned prose the parser could not read.
+  const ranked = rankModels(AVAILABLE);
+  assert.equal(ranked[0].id, 'mid/model:free');
+  assert.ok(
+    ranked.every((m, i) => i === 0 || !m.structured || ranked[i - 1].structured),
+    'every structured model sorts ahead of every unstructured one',
+  );
+});
+
+test('among equally capable models the larger context still wins', () => {
+  const ranked = rankModels([
+    { id: 'small/structured:free', context: 8000, structured: true },
+    { id: 'large/structured:free', context: 262144, structured: true },
+  ]);
+  assert.equal(ranked[0].id, 'large/structured:free');
+});
+
+test('ranking does not mutate the caller array', () => {
+  const input = [...AVAILABLE];
+  rankModels(input);
+  assert.deepEqual(
+    input.map((m) => m.id),
+    AVAILABLE.map((m) => m.id),
+  );
 });
 
 // --- end to end ------------------------------------------------------------

--- a/.github/review/scripts/test/openrouter.test.mjs
+++ b/.github/review/scripts/test/openrouter.test.mjs
@@ -49,13 +49,20 @@ index 333..444 100644
 
 test('splits a diff into per-file sections keyed by the new path', () => {
   const files = splitDiffByFile(DIFF);
-  assert.deepEqual(files.map((f) => f.file), ['src/a.ts', 'src/b.ts']);
+  assert.deepEqual(
+    files.map(f => f.file),
+    ['src/a.ts', 'src/b.ts']
+  );
   assert.match(files[0].patch, /const y = 2/);
-  assert.ok(!files[0].patch.includes('const z = 3'), 'sections must not bleed into each other');
+  assert.ok(
+    !files[0].patch.includes('const z = 3'),
+    'sections must not bleed into each other'
+  );
 });
 
 test('a renamed file is keyed by its new path', () => {
-  const renamed = 'diff --git a/old/name.ts b/new/name.ts\n--- a/old/name.ts\n+++ b/new/name.ts\n@@ -1 +1 @@\n+x\n';
+  const renamed =
+    'diff --git a/old/name.ts b/new/name.ts\n--- a/old/name.ts\n+++ b/new/name.ts\n@@ -1 +1 @@\n+x\n';
   assert.equal(splitDiffByFile(renamed)[0].file, 'new/name.ts');
 });
 
@@ -66,21 +73,31 @@ test('an empty diff yields no sections', () => {
 
 // --- chunk packing ---------------------------------------------------------
 
-const mkFiles = (sizes) => sizes.map((n, i) => ({ file: `f${i}.ts`, patch: 'x'.repeat(n) }));
+const mkFiles = sizes =>
+  sizes.map((n, i) => ({ file: `f${i}.ts`, patch: 'x'.repeat(n) }));
 
 test('small files are packed together into one request', () => {
-  const { chunks } = packChunks(mkFiles([100, 100, 100]), { budgetChars: 1000, maxChunks: 4 });
+  const { chunks } = packChunks(mkFiles([100, 100, 100]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
   assert.equal(chunks.length, 1);
   assert.equal(chunks[0].length, 3);
 });
 
 test('files are split across requests once the budget is exceeded', () => {
-  const { chunks } = packChunks(mkFiles([600, 600, 600]), { budgetChars: 1000, maxChunks: 4 });
+  const { chunks } = packChunks(mkFiles([600, 600, 600]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
   assert.equal(chunks.length, 3);
 });
 
 test('a file larger than the budget is truncated rather than dropped', () => {
-  const { chunks, truncated } = packChunks(mkFiles([5000]), { budgetChars: 1000, maxChunks: 4 });
+  const { chunks, truncated } = packChunks(mkFiles([5000]), {
+    budgetChars: 1000,
+    maxChunks: 4,
+  });
   assert.deepEqual(truncated, ['f0.ts']);
   assert.equal(chunks.length, 1);
   assert.match(chunks[0][0].patch, /diff truncated for length/);
@@ -88,7 +105,10 @@ test('a file larger than the budget is truncated rather than dropped', () => {
 });
 
 test('the request cap reports what it dropped instead of silently truncating', () => {
-  const { chunks, skipped } = packChunks(mkFiles([900, 900, 900, 900]), { budgetChars: 1000, maxChunks: 2 });
+  const { chunks, skipped } = packChunks(mkFiles([900, 900, 900, 900]), {
+    budgetChars: 1000,
+    maxChunks: 2,
+  });
   assert.equal(chunks.length, 2);
   assert.equal(skipped.length, 2);
 });
@@ -97,10 +117,16 @@ test('one huge file does not starve the small ones behind it', () => {
   // With only one request available and a file that fills the whole budget,
   // the small file must still be the one that gets reviewed.
   const { chunks, skipped } = packChunks(
-    [{ file: 'big.ts', patch: 'x'.repeat(1000) }, { file: 'small.ts', patch: 'y'.repeat(10) }],
-    { budgetChars: 1000, maxChunks: 1 },
+    [
+      { file: 'big.ts', patch: 'x'.repeat(1000) },
+      { file: 'small.ts', patch: 'y'.repeat(10) },
+    ],
+    { budgetChars: 1000, maxChunks: 1 }
   );
-  assert.deepEqual(chunks[0].map((f) => f.file), ['small.ts']);
+  assert.deepEqual(
+    chunks[0].map(f => f.file),
+    ['small.ts']
+  );
   assert.deepEqual(skipped, ['big.ts']);
 });
 
@@ -113,8 +139,14 @@ test('parses a clean JSON reply', () => {
 });
 
 test('recovers JSON from markdown fences', () => {
-  assert.deepEqual(extractJson('```json\n' + OBJ + '\n```'), { summary: 'ok', findings: [] });
-  assert.deepEqual(extractJson('```\n' + OBJ + '\n```'), { summary: 'ok', findings: [] });
+  assert.deepEqual(extractJson('```json\n' + OBJ + '\n```'), {
+    summary: 'ok',
+    findings: [],
+  });
+  assert.deepEqual(extractJson('```\n' + OBJ + '\n```'), {
+    summary: 'ok',
+    findings: [],
+  });
 });
 
 test('recovers JSON despite narration before and after', () => {
@@ -123,10 +155,13 @@ test('recovers JSON despite narration before and after', () => {
 });
 
 test('strips a reasoning model scratchpad', () => {
-  assert.deepEqual(extractJson(`<think>Let me look at this...</think>\n${OBJ}`), {
-    summary: 'ok',
-    findings: [],
-  });
+  assert.deepEqual(
+    extractJson(`<think>Let me look at this...</think>\n${OBJ}`),
+    {
+      summary: 'ok',
+      findings: [],
+    }
+  );
 });
 
 test('handles braces inside strings without losing the object', () => {
@@ -144,7 +179,11 @@ test('returns null rather than guessing on unusable output', () => {
   assert.equal(extractJson(''), null);
   assert.equal(extractJson(null), null);
   assert.equal(extractJson('{"broken": '), null);
-  assert.equal(extractJson('[1,2,3]'), null, 'a bare array is not the expected shape');
+  assert.equal(
+    extractJson('[1,2,3]'),
+    null,
+    'a bare array is not the expected shape'
+  );
 });
 
 // --- rules digest ----------------------------------------------------------
@@ -163,11 +202,14 @@ test('the digest omits muted rules, so the model cannot report them', () => {
 
 test('probation rules are included with their severity restriction', () => {
   const { digest } = buildRulesDigest(RULES, () => false);
-  assert.match(digest, /FE-005 \[minor\] Index key \(only report at blocker\/major severity\)/);
+  assert.match(
+    digest,
+    /FE-005 \[minor\] Index key \(only report at blocker\/major severity\)/
+  );
 });
 
 test('an exploration slot puts a muted rule back in play', () => {
-  const { digest, exploring } = buildRulesDigest(RULES, (id) => id === 'TS-004');
+  const { digest, exploring } = buildRulesDigest(RULES, id => id === 'TS-004');
   assert.match(digest, /TS-004/);
   assert.deepEqual(exploring, ['TS-004']);
 });
@@ -193,7 +235,11 @@ test('preferred models lead the chain when they are still available', () => {
 });
 
 test('a preferred model that no longer exists is skipped, not fatal', () => {
-  const chain = chooseModels(AVAILABLE, ['retired/model:free', 'small/model:free'], 2);
+  const chain = chooseModels(
+    AVAILABLE,
+    ['retired/model:free', 'small/model:free'],
+    2
+  );
   assert.equal(chain[0].id, 'small/model:free');
 });
 
@@ -212,8 +258,10 @@ test('a model that guarantees JSON outranks a bigger one that does not', () => {
   const ranked = rankModels(AVAILABLE);
   assert.equal(ranked[0].id, 'mid/model:free');
   assert.ok(
-    ranked.every((m, i) => i === 0 || !m.structured || ranked[i - 1].structured),
-    'every structured model sorts ahead of every unstructured one',
+    ranked.every(
+      (m, i) => i === 0 || !m.structured || ranked[i - 1].structured
+    ),
+    'every structured model sorts ahead of every unstructured one'
   );
 });
 
@@ -229,8 +277,8 @@ test('ranking does not mutate the caller array', () => {
   const input = [...AVAILABLE];
   rankModels(input);
   assert.deepEqual(
-    input.map((m) => m.id),
-    AVAILABLE.map((m) => m.id),
+    input.map(m => m.id),
+    AVAILABLE.map(m => m.id)
   );
 });
 
@@ -241,7 +289,7 @@ async function startStub({ replies, models = AVAILABLE }) {
   let i = 0;
   const server = createServer((req, res) => {
     let body = '';
-    req.on('data', (c) => (body += c));
+    req.on('data', c => (body += c));
     req.on('end', () => {
       const send = (code, payload) => {
         res.writeHead(code, { 'content-type': 'application/json' });
@@ -249,18 +297,20 @@ async function startStub({ replies, models = AVAILABLE }) {
       };
       if (req.url.endsWith('/models')) {
         return send(200, {
-          data: models.map((m) => ({
+          data: models.map(m => ({
             id: m.id,
             context_length: m.context,
             supported_parameters: m.structured ? ['structured_outputs'] : [],
           })),
         });
       }
-      if (req.url.endsWith('/key')) return send(200, { data: { usage: 1, limit: null } });
+      if (req.url.endsWith('/key'))
+        return send(200, { data: { usage: 1, limit: null } });
       if (req.url.endsWith('/chat/completions')) {
         calls.push(JSON.parse(body));
         const reply = replies[Math.min(i++, replies.length - 1)];
-        if (reply.status && reply.status !== 200) return send(reply.status, { error: reply.body });
+        if (reply.status && reply.status !== 200)
+          return send(reply.status, { error: reply.body });
         return send(200, {
           model: reply.model || 'big/model:free',
           choices: [{ message: { content: reply.content } }],
@@ -270,7 +320,7 @@ async function startStub({ replies, models = AVAILABLE }) {
       send(404, {});
     });
   });
-  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
   return { server, calls, port: server.address().port };
 }
 
@@ -287,10 +337,16 @@ async function runReview(stub, { diff = DIFF, rules, env = {} } = {}) {
     await mkdir(join(reviewDir, 'scripts', 'lib'), { recursive: true });
     await writeFile(join(reviewDir, 'rules.json'), JSON.stringify(rules));
     for (const f of ['openrouter-review.mjs']) {
-      await writeFile(join(reviewDir, 'scripts', f), await readFile(join(HERE, '..', f)));
+      await writeFile(
+        join(reviewDir, 'scripts', f),
+        await readFile(join(HERE, '..', f))
+      );
     }
     for (const f of ['openrouter.mjs', 'scoring.mjs']) {
-      await writeFile(join(reviewDir, 'scripts', 'lib', f), await readFile(join(HERE, '..', 'lib', f)));
+      await writeFile(
+        join(reviewDir, 'scripts', 'lib', f),
+        await readFile(join(HERE, '..', 'lib', f))
+      );
     }
     scriptPath = join(reviewDir, 'scripts', 'openrouter-review.mjs');
   }
@@ -305,7 +361,9 @@ async function runReview(stub, { diff = DIFF, rules, env = {} } = {}) {
       ...env,
     },
   });
-  const findings = JSON.parse(await readFile(join(dir, '.claude-review', 'findings.json'), 'utf8'));
+  const findings = JSON.parse(
+    await readFile(join(dir, '.claude-review', 'findings.json'), 'utf8')
+  );
   await rm(dir, { recursive: true, force: true });
   return { stdout, stderr, findings };
 }
@@ -314,7 +372,13 @@ const RULES_FILE = {
   version: 1,
   defaults: { explorationPercent: 0 },
   rules: {
-    'SEC-001': { title: 'Injection', severity: 'blocker', state: 'active', weight: 0.7, stats: {} },
+    'SEC-001': {
+      title: 'Injection',
+      severity: 'blocker',
+      state: 'active',
+      weight: 0.7,
+      stats: {},
+    },
   },
 };
 
@@ -330,7 +394,14 @@ const goodFinding = {
 
 test('produces findings.json in the schema post-review.mjs expects', async () => {
   const stub = await startStub({
-    replies: [{ content: JSON.stringify({ summary: 'Looks risky.', findings: [goodFinding] }) }],
+    replies: [
+      {
+        content: JSON.stringify({
+          summary: 'Looks risky.',
+          findings: [goodFinding],
+        }),
+      },
+    ],
   });
   try {
     const { findings } = await runReview(stub, { rules: RULES_FILE });
@@ -346,7 +417,12 @@ test('produces findings.json in the schema post-review.mjs expects', async () =>
 test('narrated and fenced replies still yield findings', async () => {
   const stub = await startStub({
     replies: [
-      { content: 'Sure!\n```json\n' + JSON.stringify({ summary: 's', findings: [goodFinding] }) + '\n```\nHope that helps!' },
+      {
+        content:
+          'Sure!\n```json\n' +
+          JSON.stringify({ summary: 's', findings: [goodFinding] }) +
+          '\n```\nHope that helps!',
+      },
     ],
   });
   try {
@@ -376,7 +452,11 @@ test('invented rule IDs and file paths are discarded', async () => {
   });
   try {
     const { findings, stdout } = await runReview(stub, { rules: RULES_FILE });
-    assert.equal(findings.findings.length, 1, 'only the valid finding survives');
+    assert.equal(
+      findings.findings.length,
+      1,
+      'only the valid finding survives'
+    );
     assert.match(stdout, /4 rejected/);
   } finally {
     stub.server.close();
@@ -387,7 +467,12 @@ test('an unparseable reply triggers exactly one repair attempt', async () => {
   const stub = await startStub({
     replies: [
       { content: 'I am unable to produce JSON right now.' },
-      { content: JSON.stringify({ summary: 'recovered', findings: [goodFinding] }) },
+      {
+        content: JSON.stringify({
+          summary: 'recovered',
+          findings: [goodFinding],
+        }),
+      },
     ],
   });
   try {
@@ -401,9 +486,14 @@ test('an unparseable reply triggers exactly one repair attempt', async () => {
 });
 
 test('a rate limited batch degrades to a partial review, not a crash', async () => {
-  const stub = await startStub({ replies: [{ status: 429, body: { message: 'rate limited' } }] });
+  const stub = await startStub({
+    replies: [{ status: 429, body: { message: 'rate limited' } }],
+  });
   try {
-    const { findings, stderr } = await runReview(stub, { rules: RULES_FILE, env: { MAX_REQUESTS: '1' } });
+    const { findings, stderr } = await runReview(stub, {
+      rules: RULES_FILE,
+      env: { MAX_REQUESTS: '1' },
+    });
     assert.deepEqual(findings.findings, []);
     assert.match(findings.summary, /failed/i);
     assert.match(stderr, /429/);
@@ -415,7 +505,10 @@ test('a rate limited batch degrades to a partial review, not a crash', async () 
 test('a missing API key writes an empty review instead of failing the job', async () => {
   const stub = await startStub({ replies: [{ content: OBJ }] });
   try {
-    const { findings } = await runReview(stub, { rules: RULES_FILE, env: { OPENROUTER_API_KEY: '' } });
+    const { findings } = await runReview(stub, {
+      rules: RULES_FILE,
+      env: { OPENROUTER_API_KEY: '' },
+    });
     assert.deepEqual(findings.findings, []);
     assert.match(findings.summary, /no OpenRouter API key/i);
   } finally {
@@ -424,10 +517,14 @@ test('a missing API key writes an empty review instead of failing the job', asyn
 });
 
 test('the request budget is respected and what was dropped is reported', async () => {
-  const many = Array.from({ length: 6 }, (_, i) =>
-    `diff --git a/f${i}.ts b/f${i}.ts\n--- a/f${i}.ts\n+++ b/f${i}.ts\n@@ -1 +1,2 @@\n+${'x'.repeat(30000)}\n`,
+  const many = Array.from(
+    { length: 6 },
+    (_, i) =>
+      `diff --git a/f${i}.ts b/f${i}.ts\n--- a/f${i}.ts\n+++ b/f${i}.ts\n@@ -1 +1,2 @@\n+${'x'.repeat(30000)}\n`
   ).join('');
-  const stub = await startStub({ replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }] });
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
+  });
   try {
     const { findings, stdout } = await runReview(stub, {
       diff: many,
@@ -443,10 +540,15 @@ test('the request budget is respected and what was dropped is reported', async (
 });
 
 test('the fallback chain is sent so OpenRouter can reroute on rate limits', async () => {
-  const stub = await startStub({ replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }] });
+  const stub = await startStub({
+    replies: [{ content: JSON.stringify({ summary: 's', findings: [] }) }],
+  });
   try {
     await runReview(stub, { rules: RULES_FILE });
-    assert.ok(Array.isArray(stub.calls[0].models), 'models array must be present');
+    assert.ok(
+      Array.isArray(stub.calls[0].models),
+      'models array must be present'
+    );
     assert.ok(stub.calls[0].models.length > 1, 'needs at least one fallback');
     assert.equal(stub.calls[0].temperature, 0.1);
   } finally {
@@ -457,11 +559,18 @@ test('the fallback chain is sent so OpenRouter can reroute on rate limits', asyn
 test('JSON mode is only requested when every model in the chain supports it', async () => {
   const mixed = await startStub({
     replies: [{ content: OBJ }],
-    models: [{ id: 'a:free', context: 100000, structured: true }, { id: 'b:free', context: 90000, structured: false }],
+    models: [
+      { id: 'a:free', context: 100000, structured: true },
+      { id: 'b:free', context: 90000, structured: false },
+    ],
   });
   try {
     await runReview(mixed, { rules: RULES_FILE });
-    assert.equal(mixed.calls[0].response_format, undefined, 'would 400 on the non-supporting fallback');
+    assert.equal(
+      mixed.calls[0].response_format,
+      undefined,
+      'would 400 on the non-supporting fallback'
+    );
   } finally {
     mixed.server.close();
   }
@@ -472,7 +581,9 @@ test('JSON mode is only requested when every model in the chain supports it', as
   });
   try {
     await runReview(allStructured, { rules: RULES_FILE });
-    assert.deepEqual(allStructured.calls[0].response_format, { type: 'json_object' });
+    assert.deepEqual(allStructured.calls[0].response_format, {
+      type: 'json_object',
+    });
   } finally {
     allStructured.server.close();
   }

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -22,33 +22,47 @@ const run = promisify(execFile);
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, '..', 'post-review.mjs');
 
-const PATCH = ['@@ -1,3 +1,5 @@', ' const a = 1;', '+const b = 2;', '+const c = 3;', ' const d = 4;'].join('\n');
+const PATCH = [
+  '@@ -1,3 +1,5 @@',
+  ' const a = 1;',
+  '+const b = 2;',
+  '+const c = 3;',
+  ' const d = 4;',
+].join('\n');
 
 /** Stub GitHub API. Records every request so the test can assert on them. */
 async function startStub({ existingComments = [], failReview = false } = {}) {
   const requests = [];
   const server = createServer((req, res) => {
     let body = '';
-    req.on('data', (c) => (body += c));
+    req.on('data', c => (body += c));
     req.on('end', () => {
-      requests.push({ method: req.method, url: req.url, body: body ? JSON.parse(body) : null });
+      requests.push({
+        method: req.method,
+        url: req.url,
+        body: body ? JSON.parse(body) : null,
+      });
       const send = (code, payload) => {
         res.writeHead(code, { 'content-type': 'application/json' });
         res.end(JSON.stringify(payload));
       };
 
-      if (req.url.startsWith('/repos/acme/app/pulls/7/comments')) return send(200, existingComments);
+      if (req.url.startsWith('/repos/acme/app/pulls/7/comments'))
+        return send(200, existingComments);
       if (req.url.startsWith('/repos/acme/app/pulls/7/files')) {
         return send(200, [{ filename: 'src/a.ts', patch: PATCH }]);
       }
       if (req.url.startsWith('/repos/acme/app/pulls/7/reviews')) {
-        return failReview ? send(422, { message: 'line must be part of the diff' }) : send(200, { id: 1 });
+        return failReview
+          ? send(422, { message: 'line must be part of the diff' })
+          : send(200, { id: 1 });
       }
-      if (req.url.startsWith('/repos/acme/app/issues/7/comments')) return send(201, { id: 2 });
+      if (req.url.startsWith('/repos/acme/app/issues/7/comments'))
+        return send(201, { id: 2 });
       send(404, { message: 'not found' });
     });
   });
-  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
   return { server, requests, port: server.address().port };
 }
 
@@ -58,7 +72,7 @@ async function runPostReview(findings, stub, env = {}) {
   if (findings !== null) {
     await writeFile(
       join(dir, '.claude-review', 'findings.json'),
-      typeof findings === 'string' ? findings : JSON.stringify(findings),
+      typeof findings === 'string' ? findings : JSON.stringify(findings)
     );
   }
   const { stdout, stderr } = await run(process.execPath, [SCRIPT], {
@@ -77,7 +91,10 @@ async function runPostReview(findings, stub, env = {}) {
   return { stdout, stderr };
 }
 
-const findingsPayload = (findings) => ({ summary: 'Looks reasonable overall.', findings });
+const findingsPayload = findings => ({
+  summary: 'Looks reasonable overall.',
+  findings,
+});
 
 const base = {
   ruleId: 'SEC-001',
@@ -93,7 +110,9 @@ test('posts one review with an inline comment on a line inside the diff', async 
   const stub = await startStub();
   try {
     await runPostReview(findingsPayload([base]), stub);
-    const review = stub.requests.find((r) => r.method === 'POST' && r.url.includes('/reviews'));
+    const review = stub.requests.find(
+      r => r.method === 'POST' && r.url.includes('/reviews')
+    );
     assert.ok(review, 'a review should have been posted');
     assert.equal(review.body.commit_id, 'deadbeef');
     assert.equal(review.body.event, 'COMMENT');
@@ -101,7 +120,10 @@ test('posts one review with an inline comment on a line inside the diff', async 
     assert.equal(review.body.comments[0].path, 'src/a.ts');
     assert.equal(review.body.comments[0].line, 2);
     assert.equal(review.body.comments[0].side, 'RIGHT');
-    assert.match(review.body.comments[0].body, /<!-- claude-review rule=SEC-001 fid=\w+/);
+    assert.match(
+      review.body.comments[0].body,
+      /<!-- claude-review rule=SEC-001 fid=\w+/
+    );
     assert.match(review.body.body, /## Claude review/);
   } finally {
     stub.server.close();
@@ -112,8 +134,12 @@ test('a finding outside the diff is moved into the summary, not sent inline', as
   const stub = await startStub();
   try {
     await runPostReview(findingsPayload([{ ...base, line: 999 }]), stub);
-    const review = stub.requests.find((r) => r.url.includes('/reviews'));
-    assert.equal(review.body.comments.length, 0, 'must not send an out-of-diff line');
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
+    assert.equal(
+      review.body.comments.length,
+      0,
+      'must not send an out-of-diff line'
+    );
     assert.match(review.body.body, /Findings outside the diff/);
     assert.match(review.body.body, /src\/a\.ts:999/);
   } finally {
@@ -124,8 +150,10 @@ test('a finding outside the diff is moved into the summary, not sent inline', as
 test('REQUEST_CHANGES only when explicitly enabled', async () => {
   const stub = await startStub();
   try {
-    await runPostReview(findingsPayload([base]), stub, { REQUEST_CHANGES_ON_BLOCKER: '1' });
-    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    await runPostReview(findingsPayload([base]), stub, {
+      REQUEST_CHANGES_ON_BLOCKER: '1',
+    });
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
     assert.equal(review.body.event, 'REQUEST_CHANGES');
   } finally {
     stub.server.close();
@@ -136,14 +164,17 @@ test('a finding already posted on an earlier run is not reposted', async () => {
   const existing = [
     {
       id: 100,
-      body: 'old\n<!-- claude-review rule=SEC-001 fid=' + (await import('../lib/scoring.mjs')).findingId(base) + ' -->',
+      body:
+        'old\n<!-- claude-review rule=SEC-001 fid=' +
+        (await import('../lib/scoring.mjs')).findingId(base) +
+        ' -->',
     },
   ];
   const stub = await startStub({ existingComments: existing });
   try {
     const { stdout } = await runPostReview(findingsPayload([base]), stub);
     assert.match(stdout, /No new findings since the last run/);
-    assert.equal(stub.requests.filter((r) => r.method === 'POST').length, 0);
+    assert.equal(stub.requests.filter(r => r.method === 'POST').length, 0);
   } finally {
     stub.server.close();
   }
@@ -153,7 +184,9 @@ test('falls back to a plain comment when the inline review is rejected', async (
   const stub = await startStub({ failReview: true });
   try {
     const { stdout } = await runPostReview(findingsPayload([base]), stub);
-    const fallback = stub.requests.find((r) => r.url.includes('/issues/7/comments'));
+    const fallback = stub.requests.find(r =>
+      r.url.includes('/issues/7/comments')
+    );
     assert.ok(fallback, 'should fall back rather than lose the review');
     assert.match(fallback.body.body, /SQL built by string concatenation/);
     assert.match(stdout, /fallback/i);
@@ -173,10 +206,10 @@ test('malformed model output is discarded without crashing', async () => {
         { ...base, confidence: 7 },
         base,
       ]),
-      stub,
+      stub
     );
     assert.match(stdout, /Parsed 1 valid finding\(s\), 4 discarded/);
-    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
     assert.equal(review.body.comments.length, 1);
   } finally {
     stub.server.close();
@@ -188,7 +221,7 @@ test('invalid JSON and a missing file are both survivable', async () => {
     const stub = await startStub();
     try {
       const { stdout, stderr } = await runPostReview(input, stub);
-      assert.equal(stub.requests.filter((r) => r.method === 'POST').length, 0);
+      assert.equal(stub.requests.filter(r => r.method === 'POST').length, 0);
       assert.ok(/not valid JSON|No findings.json/.test(stdout + stderr));
     } finally {
       stub.server.close();
@@ -200,9 +233,12 @@ test('a clean PR still gets a short summary', async () => {
   const stub = await startStub();
   try {
     await runPostReview(findingsPayload([]), stub);
-    const review = stub.requests.find((r) => r.url.includes('/reviews'));
+    const review = stub.requests.find(r => r.url.includes('/reviews'));
     assert.equal(review.body.comments.length, 0);
-    assert.match(review.body.body, /No findings above the confidence threshold/);
+    assert.match(
+      review.body.body,
+      /No findings above the confidence threshold/
+    );
   } finally {
     stub.server.close();
   }

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -124,7 +124,7 @@ test('posts one review with an inline comment on a line inside the diff', async 
       review.body.comments[0].body,
       /<!-- claude-review rule=SEC-001 fid=\w+/
     );
-    assert.match(review.body.body, /## Claude review/);
+    assert.match(review.body.body, /## Automated PR review/);
   } finally {
     stub.server.close();
   }

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -122,9 +122,9 @@ test('posts one review with an inline comment on a line inside the diff', async 
     assert.equal(review.body.comments[0].side, 'RIGHT');
     assert.match(
       review.body.comments[0].body,
-      /<!-- claude-review rule=SEC-001 fid=\w+/
+      /<!-- ih-tek-review rule=SEC-001 fid=\w+/
     );
-    assert.match(review.body.body, /## Automated PR review/);
+    assert.match(review.body.body, /## IH Tek review/);
   } finally {
     stub.server.close();
   }
@@ -165,7 +165,7 @@ test('a finding already posted on an earlier run is not reposted', async () => {
     {
       id: 100,
       body:
-        'old\n<!-- claude-review rule=SEC-001 fid=' +
+        'old\n<!-- ih-tek-review rule=SEC-001 fid=' +
         (await import('../lib/scoring.mjs')).findingId(base) +
         ' -->',
     },

--- a/.github/review/scripts/test/scoring.test.mjs
+++ b/.github/review/scripts/test/scoring.test.mjs
@@ -325,7 +325,7 @@ test('an empty or missing patch yields no commentable lines', () => {
 
 test('the marker written into a comment can be parsed back out', () => {
   const body =
-    'text\n<!-- claude-review rule=SEC-001 fid=abc123 conf=0.8 score=0.56 sev=major -->';
+    'text\n<!-- ih-tek-review rule=SEC-001 fid=abc123 conf=0.8 score=0.56 sev=major -->';
   assert.deepEqual(parseMarker(body), {
     rule: 'SEC-001',
     fid: 'abc123',
@@ -336,7 +336,7 @@ test('the marker written into a comment can be parsed back out', () => {
 });
 
 test('summary markers and foreign comments are ignored', () => {
-  assert.equal(parseMarker('<!-- claude-review summary -->'), null);
+  assert.equal(parseMarker('<!-- ih-tek-review summary -->'), null);
   assert.equal(parseMarker('just a human comment'), null);
   assert.equal(parseMarker(''), null);
 });

--- a/.github/review/scripts/test/scoring.test.mjs
+++ b/.github/review/scripts/test/scoring.test.mjs
@@ -65,12 +65,18 @@ test('an ignored comment counts less than an outright rejection', () => {
 
 test('one bad reaction cannot mute a rule', () => {
   const stats = { accepted: 0, rejected: 1, ignored: 0 };
-  assert.equal(computeState(computeWeight(stats), evidenceCount(stats)), 'active');
+  assert.equal(
+    computeState(computeWeight(stats), evidenceCount(stats)),
+    'active'
+  );
 });
 
 test('a consistently dismissed rule is muted once evidence accumulates', () => {
   const stats = { accepted: 0, rejected: 12, ignored: 0 };
-  assert.equal(computeState(computeWeight(stats), evidenceCount(stats)), 'muted');
+  assert.equal(
+    computeState(computeWeight(stats), evidenceCount(stats)),
+    'muted'
+  );
 });
 
 test('a mixed rule lands on probation rather than muted', () => {
@@ -84,7 +90,9 @@ test('a mixed rule lands on probation rather than muted', () => {
 
 test('feedback decays with a 90-day half-life', () => {
   assert.equal(decayFactor(NOW, NOW), 1);
-  const ninetyDaysAgo = new Date(Date.parse(NOW) - 90 * 86_400_000).toISOString();
+  const ninetyDaysAgo = new Date(
+    Date.parse(NOW) - 90 * 86_400_000
+  ).toISOString();
   assert.ok(Math.abs(decayFactor(ninetyDaysAgo, NOW) - 0.5) < 0.01);
   const yearAgo = new Date(Date.parse(NOW) - 365 * 86_400_000).toISOString();
   assert.ok(decayFactor(yearAgo, NOW) < 0.1);
@@ -99,16 +107,25 @@ test('a rule recovers as old rejections age out', () => {
     at: old,
   }));
   const { rules: next } = rebuildRules(rules, outcomes, NOW);
-  assert.ok(next['SEC-001'].weight > 0.5, 'stale rejections should stop dominating');
+  assert.ok(
+    next['SEC-001'].weight > 0.5,
+    'stale rejections should stop dominating'
+  );
   assert.equal(next['SEC-001'].state, 'active');
 });
 
 test('rebuild is idempotent and recomputes from the ledger, not from prior stats', () => {
-  const rules = { 'SEC-001': rule({ stats: { accepted: 99, rejected: 0, ignored: 0 } }) };
+  const rules = {
+    'SEC-001': rule({ stats: { accepted: 99, rejected: 0, ignored: 0 } }),
+  };
   const outcomes = [{ ruleId: 'SEC-001', outcome: 'rejected', at: NOW }];
   const a = rebuildRules(rules, outcomes, NOW);
   const b = rebuildRules(a.rules, outcomes, NOW);
-  assert.equal(a.rules['SEC-001'].stats.accepted, 0, 'stale stats must be discarded');
+  assert.equal(
+    a.rules['SEC-001'].stats.accepted,
+    0,
+    'stale stats must be discarded'
+  );
   assert.deepEqual(a.rules['SEC-001'].stats, b.rules['SEC-001'].stats);
   assert.equal(a.rules['SEC-001'].weight, b.rules['SEC-001'].weight);
   assert.equal(b.changes.length, 0, 'a second identical run changes nothing');
@@ -116,7 +133,11 @@ test('rebuild is idempotent and recomputes from the ledger, not from prior stats
 
 test('rebuild records what changed', () => {
   const rules = { 'SEC-001': rule() };
-  const outcomes = Array.from({ length: 12 }, () => ({ ruleId: 'SEC-001', outcome: 'rejected', at: NOW }));
+  const outcomes = Array.from({ length: 12 }, () => ({
+    ruleId: 'SEC-001',
+    outcome: 'rejected',
+    at: NOW,
+  }));
   const { changes } = rebuildRules(rules, outcomes, NOW);
   assert.equal(changes.length, 1);
   assert.deepEqual(changes[0].state, ['active', 'muted']);
@@ -125,7 +146,11 @@ test('rebuild records what changed', () => {
 // --- gating ----------------------------------------------------------------
 
 test('a healthy rule with a confident finding gets posted', () => {
-  const { kept } = gateFindings([finding()], { 'SEC-001': rule() }, { prNumber: 1 });
+  const { kept } = gateFindings(
+    [finding()],
+    { 'SEC-001': rule() },
+    { prNumber: 1 }
+  );
   assert.equal(kept.length, 1);
   assert.equal(kept[0]._score, 0.56);
 });
@@ -134,14 +159,18 @@ test('a low-weight rule is filtered out even at high confidence', () => {
   const { kept, dropped } = gateFindings(
     [finding({ confidence: 0.9 })],
     { 'SEC-001': rule({ weight: 0.35 }) },
-    { prNumber: 1 },
+    { prNumber: 1 }
   );
   assert.equal(kept.length, 0);
   assert.match(dropped[0].reason, /below major gate/);
 });
 
 test('unknown rule ids are dropped, not posted', () => {
-  const { kept, dropped } = gateFindings([finding({ ruleId: 'NOPE-999' })], {}, { prNumber: 1 });
+  const { kept, dropped } = gateFindings(
+    [finding({ ruleId: 'NOPE-999' })],
+    {},
+    { prNumber: 1 }
+  );
   assert.equal(kept.length, 0);
   assert.match(dropped[0].reason, /unknown rule/);
 });
@@ -150,10 +179,16 @@ test('muted rules stay silent on ordinary pull requests', () => {
   const rules = { 'SEC-001': rule({ state: 'muted', weight: 0.2 }) };
   let silent = 0;
   for (let pr = 1; pr <= 100; pr++) {
-    const { kept } = gateFindings([finding()], rules, { prNumber: pr, explorationPercent: 10 });
+    const { kept } = gateFindings([finding()], rules, {
+      prNumber: pr,
+      explorationPercent: 10,
+    });
     if (kept.length === 0) silent++;
   }
-  assert.ok(silent >= 85 && silent < 100, `expected ~90 silent PRs, got ${silent}`);
+  assert.ok(
+    silent >= 85 && silent < 100,
+    `expected ~90 silent PRs, got ${silent}`
+  );
 });
 
 test('an exploration slot actually posts, bypassing the score gate', () => {
@@ -163,48 +198,84 @@ test('an exploration slot actually posts, bypassing the score gate', () => {
   const rules = { 'SEC-001': rule({ state: 'muted', weight: 0.15 }) };
   const explored = [];
   for (let pr = 1; pr <= 200; pr++) {
-    const { kept } = gateFindings([finding()], rules, { prNumber: pr, explorationPercent: 10 });
+    const { kept } = gateFindings([finding()], rules, {
+      prNumber: pr,
+      explorationPercent: 10,
+    });
     if (kept.length) explored.push({ pr, kept });
   }
   assert.ok(explored.length > 0, 'muted rules must occasionally be re-tested');
-  assert.equal(explored[0].kept[0]._exploring, true, 'explored findings are flagged as such');
+  assert.equal(
+    explored[0].kept[0]._exploring,
+    true,
+    'explored findings are flagged as such'
+  );
 });
 
 test('exploration is deterministic, so re-runs on a PR agree', () => {
   const a = isExplorationSlot('SEC-001', 42, 10);
-  for (let i = 0; i < 20; i++) assert.equal(isExplorationSlot('SEC-001', 42, 10), a);
-  assert.equal(isExplorationSlot('SEC-001', 42, 0), false, '0% disables exploration');
+  for (let i = 0; i < 20; i++)
+    assert.equal(isExplorationSlot('SEC-001', 42, 10), a);
+  assert.equal(
+    isExplorationSlot('SEC-001', 42, 0),
+    false,
+    '0% disables exploration'
+  );
 });
 
 test('probation suppresses minor and nit findings but keeps blockers', () => {
   const rules = { 'SEC-001': rule({ state: 'probation', weight: 0.45 }) };
   const opts = { prNumber: 1 };
-  assert.equal(gateFindings([finding({ severity: 'minor', confidence: 1 })], rules, opts).kept.length, 0);
-  assert.equal(gateFindings([finding({ severity: 'blocker', confidence: 1 })], rules, opts).kept.length, 1);
+  assert.equal(
+    gateFindings([finding({ severity: 'minor', confidence: 1 })], rules, opts)
+      .kept.length,
+    0
+  );
+  assert.equal(
+    gateFindings([finding({ severity: 'blocker', confidence: 1 })], rules, opts)
+      .kept.length,
+    1
+  );
 });
 
 test('findings already posted are not posted again', () => {
   const f = finding();
-  const { kept, dropped } = gateFindings([f], { 'SEC-001': rule() }, {
-    prNumber: 1,
-    alreadyPosted: new Set([findingId(f)]),
-  });
+  const { kept, dropped } = gateFindings(
+    [f],
+    { 'SEC-001': rule() },
+    {
+      prNumber: 1,
+      alreadyPosted: new Set([findingId(f)]),
+    }
+  );
   assert.equal(kept.length, 0);
   assert.match(dropped[0].reason, /already posted/);
 });
 
 test('finding ids are stable across reruns but distinguish real differences', () => {
-  assert.equal(findingId(finding()), findingId(finding({ body: 'reworded', confidence: 0.99 })));
+  assert.equal(
+    findingId(finding()),
+    findingId(finding({ body: 'reworded', confidence: 0.99 }))
+  );
   assert.notEqual(findingId(finding()), findingId(finding({ line: 11 })));
-  assert.notEqual(findingId(finding()), findingId(finding({ file: 'src/b.ts' })));
+  assert.notEqual(
+    findingId(finding()),
+    findingId(finding({ file: 'src/b.ts' }))
+  );
 });
 
 test('the comment cap keeps the most severe findings', () => {
   const many = [
-    ...Array.from({ length: 8 }, (_, i) => finding({ severity: 'nit', line: 100 + i, confidence: 1 })),
+    ...Array.from({ length: 8 }, (_, i) =>
+      finding({ severity: 'nit', line: 100 + i, confidence: 1 })
+    ),
     finding({ severity: 'blocker', line: 5, confidence: 0.9 }),
   ];
-  const { kept } = gateFindings(many, { 'SEC-001': rule() }, { prNumber: 1, maxComments: 3 });
+  const { kept } = gateFindings(
+    many,
+    { 'SEC-001': rule() },
+    { prNumber: 1, maxComments: 3 }
+  );
   assert.equal(kept.length, 3);
   assert.equal(kept[0].severity, 'blocker');
 });
@@ -233,7 +304,10 @@ const PATCH = [
 
 test('commentable lines follow the new-file numbering', () => {
   const lines = commentableLines(PATCH);
-  assert.deepEqual([...lines].sort((a, b) => a - b), [1, 2, 3, 4, 5, 22, 23, 24]);
+  assert.deepEqual(
+    [...lines].sort((a, b) => a - b),
+    [1, 2, 3, 4, 5, 22, 23, 24]
+  );
 });
 
 test('lines outside any hunk are not commentable', () => {
@@ -250,7 +324,8 @@ test('an empty or missing patch yields no commentable lines', () => {
 // --- marker round-trip -----------------------------------------------------
 
 test('the marker written into a comment can be parsed back out', () => {
-  const body = 'text\n<!-- claude-review rule=SEC-001 fid=abc123 conf=0.8 score=0.56 sev=major -->';
+  const body =
+    'text\n<!-- claude-review rule=SEC-001 fid=abc123 conf=0.8 score=0.56 sev=major -->';
   assert.deepEqual(parseMarker(body), {
     rule: 'SEC-001',
     fid: 'abc123',
@@ -268,47 +343,79 @@ test('summary markers and foreign comments are ignored', () => {
 
 // --- outcome scoring -------------------------------------------------------
 
-const react = (c) => [{ content: c }];
+const react = c => [{ content: c }];
 
 test('an explicit reaction beats every other signal', () => {
   assert.equal(
-    scoreComment({ reactions: react('-1'), thread: { isOutdated: true }, prClosed: true }).outcome,
-    'rejected',
+    scoreComment({
+      reactions: react('-1'),
+      thread: { isOutdated: true },
+      prClosed: true,
+    }).outcome,
+    'rejected'
   );
-  assert.equal(scoreComment({ reactions: react('+1'), prClosed: false }).outcome, 'accepted');
+  assert.equal(
+    scoreComment({ reactions: react('+1'), prClosed: false }).outcome,
+    'accepted'
+  );
 });
 
 test('a dismissive reply counts against the rule', () => {
-  const r = scoreComment({ reactions: [], thread: { replies: ['This is a false positive.'] }, prClosed: true });
+  const r = scoreComment({
+    reactions: [],
+    thread: { replies: ['This is a false positive.'] },
+    prClosed: true,
+  });
   assert.equal(r.outcome, 'rejected');
   assert.equal(r.signal, 'reply-dismissal');
 });
 
 test('an agreeing reply counts for the rule', () => {
-  const r = scoreComment({ reactions: [], thread: { replies: ['Good catch, fixed.'] }, prClosed: true });
+  const r = scoreComment({
+    reactions: [],
+    thread: { replies: ['Good catch, fixed.'] },
+    prClosed: true,
+  });
   assert.equal(r.outcome, 'accepted');
 });
 
 test('code changing under the comment counts as agreement', () => {
-  const r = scoreComment({ reactions: [], thread: { replies: [] }, prClosed: false, isOutdated: true });
+  const r = scoreComment({
+    reactions: [],
+    thread: { replies: [] },
+    prClosed: false,
+    isOutdated: true,
+  });
   assert.equal(r.outcome, 'accepted');
   assert.equal(r.signal, 'code-changed-after-comment');
 });
 
 test('silence scores only once the PR is closed', () => {
-  assert.equal(scoreComment({ reactions: [], thread: {}, prClosed: false }).outcome, 'undecided');
-  assert.equal(scoreComment({ reactions: [], thread: {}, prClosed: true }).outcome, 'ignored');
+  assert.equal(
+    scoreComment({ reactions: [], thread: {}, prClosed: false }).outcome,
+    'undecided'
+  );
+  assert.equal(
+    scoreComment({ reactions: [], thread: {}, prClosed: true }).outcome,
+    'ignored'
+  );
 });
 
 // --- rulebook integrity ----------------------------------------------------
 
 test('review-rules.md and rules.json describe the same rules', () => {
-  const md = parseRulebook(readFileSync(join(REVIEW_DIR, 'review-rules.md'), 'utf8'));
+  const md = parseRulebook(
+    readFileSync(join(REVIEW_DIR, 'review-rules.md'), 'utf8')
+  );
   const book = JSON.parse(readFileSync(join(REVIEW_DIR, 'rules.json'), 'utf8'));
   assert.ok(Object.keys(md).length > 0, 'no rules parsed from the markdown');
   assert.deepEqual(Object.keys(md).sort(), Object.keys(book.rules).sort());
   for (const [id, meta] of Object.entries(md)) {
-    assert.equal(book.rules[id].severity, meta.severity, `${id} severity mismatch`);
+    assert.equal(
+      book.rules[id].severity,
+      meta.severity,
+      `${id} severity mismatch`
+    );
     assert.equal(book.rules[id].title, meta.title, `${id} title mismatch`);
   }
 });
@@ -316,7 +423,10 @@ test('review-rules.md and rules.json describe the same rules', () => {
 test('every rule carries a severity the gates understand', () => {
   const book = JSON.parse(readFileSync(join(REVIEW_DIR, 'rules.json'), 'utf8'));
   for (const [id, r] of Object.entries(book.rules)) {
-    assert.ok(SEVERITY_GATES[r.severity], `${id} has an unknown severity: ${r.severity}`);
+    assert.ok(
+      SEVERITY_GATES[r.severity],
+      `${id} has an unknown severity: ${r.severity}`
+    );
     assert.ok(r.weight >= 0 && r.weight <= 1, `${id} weight out of range`);
   }
 });

--- a/.github/review/scripts/tune-rules.mjs
+++ b/.github/review/scripts/tune-rules.mjs
@@ -38,7 +38,7 @@ const REPORT_PATH = process.env.REPORT_PATH || 'tuning-report.md';
 
 const REPO = process.env.REPO;
 const NOW = process.env.RUN_TIMESTAMP || new Date().toISOString();
-const MARKER = 'claude-review';
+const MARKER = 'ih-tek-review';
 const MAX_LEDGER_ENTRIES = 5000;
 
 const argv = process.argv.slice(2);

--- a/.github/review/scripts/tune-rules.mjs
+++ b/.github/review/scripts/tune-rules.mjs
@@ -43,10 +43,15 @@ const MAX_LEDGER_ENTRIES = 5000;
 
 const argv = process.argv.slice(2);
 const DRY_RUN = argv.includes('--dry-run');
-const DAYS = Number(argv[argv.indexOf('--days') + 1]) || Number(process.env.LOOKBACK_DAYS) || 30;
+const DAYS =
+  Number(argv[argv.indexOf('--days') + 1]) ||
+  Number(process.env.LOOKBACK_DAYS) ||
+  30;
 
-const DISMISSAL = /\b(false positive|not an issue|not a problem|wontfix|won't fix|by design|intentional|disagree|incorrect|irrelevant|out of scope|already handled|no it('?s| is) not)\b/i;
-const AGREEMENT = /\b(good catch|nice catch|great catch|fixed|done|will fix|fixing|addressed|thanks|thank you|agreed|you'?re right|makes sense)\b/i;
+const DISMISSAL =
+  /\b(false positive|not an issue|not a problem|wontfix|won't fix|by design|intentional|disagree|incorrect|irrelevant|out of scope|already handled|no it('?s| is) not)\b/i;
+const AGREEMENT =
+  /\b(good catch|nice catch|great catch|fixed|done|will fix|fixing|addressed|thanks|thank you|agreed|you'?re right|makes sense)\b/i;
 
 function log(...a) {
   console.log(...a);
@@ -105,9 +110,16 @@ async function fetchThreadState(repo, prNumber) {
   for (let page = 0; page < 10; page++) {
     let data;
     try {
-      data = await graphql(query, { owner, name, number: Number(prNumber), cursor });
+      data = await graphql(query, {
+        owner,
+        name,
+        number: Number(prNumber),
+        cursor,
+      });
     } catch (err) {
-      log(`  GraphQL thread lookup failed (${err.message.slice(0, 120)}); falling back to REST signals only.`);
+      log(
+        `  GraphQL thread lookup failed (${err.message.slice(0, 120)}); falling back to REST signals only.`
+      );
       return byComment;
     }
     const threads = data?.repository?.pullRequest?.reviewThreads;
@@ -117,11 +129,13 @@ async function fetchThreadState(repo, prNumber) {
       const nodes = t.comments?.nodes || [];
       const root = nodes[0];
       if (!root?.databaseId) continue;
-      const replies = nodes.slice(1).filter((c) => !/\[bot\]$/.test(c.author?.login || ''));
+      const replies = nodes
+        .slice(1)
+        .filter(c => !/\[bot\]$/.test(c.author?.login || ''));
       byComment.set(root.databaseId, {
         isResolved: t.isResolved,
         isOutdated: t.isOutdated,
-        replies: replies.map((r) => r.body || ''),
+        replies: replies.map(r => r.body || ''),
       });
     }
 
@@ -136,13 +150,16 @@ async function fetchThreadState(repo, prNumber) {
  * @returns {{outcome:'accepted'|'rejected'|'ignored'|'undecided', signal:string}}
  */
 function scoreComment({ reactions, thread, prClosed, isOutdated }) {
-  const has = (c) => reactions.some((r) => r.content === c);
+  const has = c => reactions.some(r => r.content === c);
   if (has('-1')) return { outcome: 'rejected', signal: 'thumbs-down' };
-  if (has('+1') || has('hooray') || has('rocket')) return { outcome: 'accepted', signal: 'thumbs-up' };
+  if (has('+1') || has('hooray') || has('rocket'))
+    return { outcome: 'accepted', signal: 'thumbs-up' };
 
   for (const reply of thread?.replies || []) {
-    if (DISMISSAL.test(reply)) return { outcome: 'rejected', signal: 'reply-dismissal' };
-    if (AGREEMENT.test(reply)) return { outcome: 'accepted', signal: 'reply-agreement' };
+    if (DISMISSAL.test(reply))
+      return { outcome: 'rejected', signal: 'reply-dismissal' };
+    if (AGREEMENT.test(reply))
+      return { outcome: 'accepted', signal: 'reply-agreement' };
   }
 
   if (isOutdated || thread?.isOutdated) {
@@ -158,18 +175,24 @@ async function harvest(ledger) {
   log(`Scanning pull requests in ${REPO} updated since ${since}...`);
 
   const prs = (
-    await restAll(`/repos/${REPO}/pulls?state=all&sort=updated&direction=desc`, { max: 300 })
-  ).filter((pr) => pr.updated_at >= since);
+    await restAll(
+      `/repos/${REPO}/pulls?state=all&sort=updated&direction=desc`,
+      { max: 300 }
+    )
+  ).filter(pr => pr.updated_at >= since);
   log(`${prs.length} pull request(s) in window.`);
 
   let scanned = 0;
   let scored = 0;
 
   for (const pr of prs) {
-    const comments = await restAll(`/repos/${REPO}/pulls/${pr.number}/comments`, { max: 200 });
+    const comments = await restAll(
+      `/repos/${REPO}/pulls/${pr.number}/comments`,
+      { max: 200 }
+    );
     const ours = comments
-      .map((c) => ({ comment: c, marker: parseMarker(c.body) }))
-      .filter((x) => x.marker);
+      .map(c => ({ comment: c, marker: parseMarker(c.body) }))
+      .filter(x => x.marker);
     if (ours.length === 0) continue;
 
     scanned += ours.length;
@@ -220,7 +243,10 @@ function pruneLedger(ledger) {
   const ids = Object.keys(ledger.entries);
   if (ids.length <= MAX_LEDGER_ENTRIES) return ledger;
   const keep = ids
-    .sort((a, b) => Date.parse(ledger.entries[b].at) - Date.parse(ledger.entries[a].at))
+    .sort(
+      (a, b) =>
+        Date.parse(ledger.entries[b].at) - Date.parse(ledger.entries[a].at)
+    )
     .slice(0, MAX_LEDGER_ENTRIES);
   const entries = {};
   for (const id of keep) entries[id] = ledger.entries[id];
@@ -229,7 +255,10 @@ function pruneLedger(ledger) {
 
 function writeReport(book, next, changes, ledger) {
   const outcomes = Object.values(ledger.entries);
-  const tally = outcomes.reduce((acc, o) => ((acc[o.outcome] = (acc[o.outcome] || 0) + 1), acc), {});
+  const tally = outcomes.reduce(
+    (acc, o) => ((acc[o.outcome] = (acc[o.outcome] || 0) + 1), acc),
+    {}
+  );
 
   const lines = [
     '## Review agent tuning report',
@@ -244,44 +273,59 @@ function writeReport(book, next, changes, ledger) {
   if (changes.length === 0) {
     lines.push('No rule weights changed this run.');
   } else {
-    lines.push('### Rules that moved', '', '| Rule | Weight | State | Evidence |', '| --- | --- | --- | --- |');
+    lines.push(
+      '### Rules that moved',
+      '',
+      '| Rule | Weight | State | Evidence |',
+      '| --- | --- | --- | --- |'
+    );
     for (const c of changes.sort((a, b) => a.weight[1] - b.weight[1])) {
       const arrow = c.weight[1] < c.weight[0] ? '↓' : '↑';
-      const state = c.state[0] === c.state[1] ? c.state[1] : `**${c.state[0]} → ${c.state[1]}**`;
+      const state =
+        c.state[0] === c.state[1]
+          ? c.state[1]
+          : `**${c.state[0]} → ${c.state[1]}**`;
       lines.push(
         `| \`${c.ruleId}\` ${c.title} | ${c.weight[0]} ${arrow} ${c.weight[1]} | ${state} | ` +
-          `${c.stats.accepted}✓ / ${c.stats.rejected}✗ / ${c.stats.ignored}∅ |`,
+          `${c.stats.accepted}✓ / ${c.stats.rejected}✗ / ${c.stats.ignored}∅ |`
       );
     }
   }
 
   const muted = Object.entries(next).filter(([, r]) => r.state === 'muted');
-  const probation = Object.entries(next).filter(([, r]) => r.state === 'probation');
+  const probation = Object.entries(next).filter(
+    ([, r]) => r.state === 'probation'
+  );
 
   if (muted.length) {
     lines.push('', '### Currently muted', '');
     for (const [id, r] of muted) {
-      lines.push(`- \`${id}\` ${r.title} — weight ${r.weight} over ${evidenceCount(r.stats).toFixed(1)} observations`);
+      lines.push(
+        `- \`${id}\` ${r.title} — weight ${r.weight} over ${evidenceCount(r.stats).toFixed(1)} observations`
+      );
     }
     lines.push(
       '',
       `Muted rules are still re-tested on roughly ${book.defaults?.explorationPercent ?? 10}% of pull requests, ` +
-        'so a rule that was fixed can earn its way back without anyone intervening.',
+        'so a rule that was fixed can earn its way back without anyone intervening.'
     );
   }
   if (probation.length) {
     lines.push('', '### On probation (blocker/major findings only)', '');
-    for (const [id, r] of probation) lines.push(`- \`${id}\` ${r.title} — weight ${r.weight}`);
+    for (const [id, r] of probation)
+      lines.push(`- \`${id}\` ${r.title} — weight ${r.weight}`);
   }
 
-  const gen = outcomes.filter((o) => o.ruleId === 'GEN-000' && o.outcome === 'accepted').length;
+  const gen = outcomes.filter(
+    o => o.ruleId === 'GEN-000' && o.outcome === 'accepted'
+  ).length;
   if (gen > 0) {
     lines.push(
       '',
       `### Worth a look`,
       '',
       `${gen} accepted \`GEN-000\` finding(s) in the ledger — real problems no rule covers yet. ` +
-        'Read them and consider promoting the recurring ones into `review-rules.md`.',
+        'Read them and consider promoting the recurring ones into `review-rules.md`.'
     );
   }
 
@@ -291,7 +335,7 @@ function writeReport(book, next, changes, ledger) {
     '',
     'Weights are the mean of a Beta posterior per rule, seeded at 0.7 and updated from human ' +
       'reactions, thread replies, and whether the flagged code actually changed. Observations ' +
-      'decay with a 90-day half-life so the rulebook reflects how each rule behaves now.',
+      'decay with a 90-day half-life so the rulebook reflects how each rule behaves now.'
   );
 
   const report = lines.join('\n');
@@ -307,7 +351,7 @@ async function main() {
 
   ledger = pruneLedger(await harvest(ledger));
 
-  const outcomes = Object.values(ledger.entries).map((e) => ({
+  const outcomes = Object.values(ledger.entries).map(e => ({
     ruleId: e.ruleId,
     outcome: e.outcome,
     at: e.at,
@@ -330,28 +374,45 @@ async function main() {
     ledger.lastRunAt = NOW;
     writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n');
     if (process.env.GITHUB_OUTPUT) {
-      writeFileSync(process.env.GITHUB_OUTPUT, 'changed=false\n', { flag: 'a' });
+      writeFileSync(process.env.GITHUB_OUTPUT, 'changed=false\n', {
+        flag: 'a',
+      });
     }
     return;
   }
 
   writeFileSync(
     RULES_PATH,
-    JSON.stringify({ ...book, version: (book.version || 0) + 1, updatedAt: NOW, rules: nextRules }, null, 2) + '\n',
+    JSON.stringify(
+      {
+        ...book,
+        version: (book.version || 0) + 1,
+        updatedAt: NOW,
+        rules: nextRules,
+      },
+      null,
+      2
+    ) + '\n'
   );
   ledger.lastRunAt = NOW;
   writeFileSync(LEDGER_PATH, JSON.stringify(ledger, null, 2) + '\n');
 
-  log(`Updated ${changes.length} rule(s); rulebook is now v${(book.version || 0) + 1}.`);
+  log(
+    `Updated ${changes.length} rule(s); rulebook is now v${(book.version || 0) + 1}.`
+  );
   if (process.env.GITHUB_OUTPUT) {
-    writeFileSync(process.env.GITHUB_OUTPUT, `changed=true\nchange_count=${changes.length}\n`, { flag: 'a' });
+    writeFileSync(
+      process.env.GITHUB_OUTPUT,
+      `changed=true\nchange_count=${changes.length}\n`,
+      { flag: 'a' }
+    );
   }
 }
 
 // Only run when invoked directly, so the scoring helpers above stay importable
 // from the test file.
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((err) => {
+  main().catch(err => {
     console.error(`tune-rules failed: ${err.stack || err.message}`);
     process.exit(1);
   });

--- a/.github/workflows/claude-review-tuning.yml
+++ b/.github/workflows/claude-review-tuning.yml
@@ -1,4 +1,4 @@
-name: Claude Review Tuning
+name: IH Tek Review Tuning
 
 # Two jobs:
 #   validate — on any PR that touches the review config, prove that
@@ -79,7 +79,7 @@ jobs:
         if: steps.tune.outputs.changed == 'true' && github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: chore/claude-review-tuning
+          BRANCH: chore/ih-tek-review-tuning
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           CHANGE_COUNT: ${{ steps.tune.outputs.change_count }}
         run: |
@@ -95,7 +95,7 @@ jobs:
           git push --force origin "$BRANCH"
 
           # Label is optional; create it once, ignore the error if it exists.
-          gh label create claude-review-tuning \
+          gh label create ih-tek-review-tuning \
             --color BFD4F2 --description "Automated review rule weight updates" 2>/dev/null || true
 
           if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
@@ -107,5 +107,5 @@ jobs:
               --head "$BRANCH" \
               --title "chore(review): retune rule weights from PR feedback" \
               --body-file tuning-report.md \
-              --label "claude-review-tuning"
+              --label "ih-tek-review-tuning"
           fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,45 +2,145 @@ name: PR Review
 
 # Automated PR review using OpenRouter free models.
 #
-# Same three-step shape as before — prepare the diff, generate findings, post
-# them — but the middle step is now a plain script calling OpenRouter instead of
-# an agentic action. post-review.mjs, the rule gating and the feedback loop are
-# untouched: only the thing producing findings.json changed.
+# Three steps — prepare the diff, generate findings, post them. post-review.mjs,
+# the rule gating and the feedback loop are provider-agnostic: only the middle
+# step knows it is talking to OpenRouter.
+#
+# When this runs:
+#   - a PR into main or dev is opened, reopened, or marked ready for review
+#   - someone adds the `review-again` label to such a PR
+#   - someone with write access comments `/review` on it
+#
+# Deliberately NOT on `synchronize`. Pushing follow-up commits to an open PR
+# does not re-review it, which keeps the OpenRouter free tier (50 requests/day,
+# 4 per review) from being spent on work-in-progress. The cost is that a review
+# goes stale as soon as the author pushes a fix — re-request it with the label
+# or the comment when the diff has moved enough to be worth another pass.
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, labeled]
+    # Base branch, i.e. what the PR merges INTO. PRs targeting anything else
+    # (qa, staging, feature branches) are not reviewed.
+    branches: [main, dev]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
+  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   review:
+    # Two ways in. The pull_request path is filtered by `branches:` above; the
+    # issue_comment path cannot be (that event has no branch context), so the
+    # base branch is checked in the Resolve step instead.
+    #
+    # `/review` is restricted to people with write access. Without that gate any
+    # drive-by commenter could burn the day's request budget.
     if: >
-      github.event.pull_request.draft == false &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'review-again')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
+      - name: Resolve pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "pull_request" ]; then
+            NUMBER="$PR_FROM_EVENT"
+          else
+            NUMBER="$ISSUE_NUMBER"
+          fi
+
+          # Read head/base from the API rather than the event payload so both
+          # entry points agree, and so a comment made minutes ago still resolves
+          # to the PR's current head.
+          DATA=$(gh pr view "$NUMBER" --repo "$REPO" \
+            --json headRefOid,baseRefOid,baseRefName,isDraft,labels,state)
+
+          BASE_REF=$(echo "$DATA" | jq -r .baseRefName)
+          IS_DRAFT=$(echo "$DATA" | jq -r .isDraft)
+          STATE=$(echo "$DATA" | jq -r .state)
+          SKIP=$(echo "$DATA" | jq -r '[.labels[].name] | index("skip-review") // "" ')
+
+          # The `branches:` filter does not apply to issue_comment, so enforce
+          # the same rule here for the comment path.
+          if [ "$BASE_REF" != "main" ] && [ "$BASE_REF" != "dev" ]; then
+            echo "PR #${NUMBER} targets '${BASE_REF}', not main or dev. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #${NUMBER} is ${STATE}. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "PR #${NUMBER} is a draft. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -n "$SKIP" ]; then
+            echo "PR #${NUMBER} carries skip-review. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          {
+            echo "run=true"
+            echo "number=${NUMBER}"
+            echo "head_sha=$(echo "$DATA" | jq -r .headRefOid)"
+            echo "base_sha=$(echo "$DATA" | jq -r .baseRefOid)"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Reviewing PR #${NUMBER} into ${BASE_REF}."
+
+      - name: Acknowledge the request
+        if: steps.pr.outputs.run == 'true' && github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST \
+            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes --silent || true
+
       - name: Checkout
+        if: steps.pr.outputs.run == 'true'
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
+        if: steps.pr.outputs.run == 'true'
         with:
           node-version: '20'
 
       - name: Prepare diff
+        if: steps.pr.outputs.run == 'true'
         id: prep
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set -euo pipefail
           mkdir -p .claude-review
@@ -61,37 +161,50 @@ jobs:
           echo "Diff: ${BYTES} bytes, $(wc -l < .claude-review/changed-files.txt) file(s)."
 
       - name: Generate findings
+        if: steps.pr.outputs.run == 'true'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional. Preferred models, best first — any that are no longer free
           # are skipped and the script falls back to whatever currently is.
-          # Leave unset to just use the largest-context free models available.
+          # Leave unset and it picks structured-output-capable free models,
+          # largest context first.
           OPENROUTER_MODELS: ${{ vars.OPENROUTER_MODELS }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
           # Passed as env, not interpolated into a shell command — a PR title is
           # attacker-controlled text and must never reach a `run:` block inline.
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           # Each batch is one OpenRouter request. The free tier allows 50 per
-          # day, or 1000 once the account has bought $10 of credit. Four keeps a
-          # busy repo inside the smaller budget.
+          # day, or 1000 once the account has bought $10 of credit.
           MAX_REQUESTS: '4'
         run: node .github/review/scripts/openrouter-review.mjs
 
       - name: Post review
+        if: steps.pr.outputs.run == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           REQUEST_CHANGES_ON_BLOCKER: '0'
         run: node .github/review/scripts/post-review.mjs
 
+      - name: Clear the review-again label
+        # Removed so it can be applied again. A label that stays put can only
+        # trigger once, which is a confusing way for an on-demand switch to fail.
+        if: always() && github.event.action == 'labeled' && github.event.label.name == 'review-again'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/review-again" \
+            --silent || true
+
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.pr.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: review-${{ github.event.pull_request.number }}
+          name: review-${{ steps.pr.outputs.number }}
           path: .claude-review/
           retention-days: 14
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -77,9 +77,17 @@ This project uses **Husky** to enforce code quality standards before each commit
 
 ## 🤖 Automated PR Review
 
-Every non-draft pull request is reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 56 rules covering security, PHI handling, data access, async correctness, realtime, frontend, TypeScript, tests, and ops.
+Pull requests are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 56 rules covering security, PHI handling, data access, async correctness, realtime, frontend, TypeScript, tests, and ops.
 
-**How it runs** ([.github/workflows/pr-review.yml](.github/workflows/pr-review.yml)):
+**When it runs** ([.github/workflows/pr-review.yml](.github/workflows/pr-review.yml)):
+
+- a non-draft PR **into `main` or `dev`** is opened, reopened, or marked ready for review
+- someone adds the **`review-again`** label (removed afterwards, so it can be reapplied)
+- someone with write access comments **`/review`**
+
+It does **not** re-review on every push. That keeps the free-tier budget for changes worth reading, at the cost of a review going stale once the author pushes a fix — ask for a fresh one with the label or the comment.
+
+**How it runs:**
 
 1. **Prepare** — computes the diff against the merge base, excluding lockfiles, snapshots, and build output
 2. **Review** — sends the diff and a rules digest to a free OpenRouter model, producing structured findings
@@ -92,6 +100,8 @@ Every non-draft pull request is reviewed against a written rulebook at [.github/
 **Required setup:** an `OPENROUTER_API_KEY` repository secret. Turn training **off** for free models in OpenRouter's privacy settings before enabling — diffs of clinical code can carry table names, field names, and fixture data.
 
 **Opting out:** add the `skip-review` label to a PR. The review never blocks a merge; it posts as a comment.
+
+**Note:** `/review` only works once this is merged to `main` — GitHub runs comment-triggered workflows from the default branch. The label and the open/reopen triggers work from a PR branch immediately.
 
 Adding or removing a rule means editing `review-rules.md` and running `node .github/review/scripts/sync-rules.mjs --write`. CI fails any PR where the rulebook and `rules.json` disagree. Full design notes: [.github/review/README.md](.github/review/README.md).
 

--- a/src/utils/sentry.test.ts
+++ b/src/utils/sentry.test.ts
@@ -26,8 +26,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackHealthWorkerAction', () => {
     it('should track health worker action with proper tags and context', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackHealthWorkerAction('patient_view', {
         patientId: '123',
@@ -49,8 +50,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackPatientInteraction', () => {
     it('should track patient interaction with proper tags and context', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackPatientInteraction('consultation', 'patient_123', {
         duration: 30,
@@ -73,8 +75,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackFormSubmission', () => {
     it('should track successful form submission', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackFormSubmission('patient_registration', true, {
         patientId: '123',
@@ -94,8 +97,9 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed form submission', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackFormSubmission('patient_registration', false, {
         patientId: '123',
@@ -117,8 +121,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackApiError', () => {
     it('should track API error with proper tags and context', async () => {
-      const { setTag, setContext, captureException } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureException } = await import(
+        '../config/sentry'
+      );
       const error = new Error('API timeout');
 
       trackApiError('/api/patients', error, {
@@ -138,8 +143,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackCriticalOperation', () => {
     it('should track successful critical operation', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackCriticalOperation('patient_data_sync', 1500, true);
 
@@ -155,8 +161,9 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed critical operation', async () => {
-      const { setTag, setContext, captureMessage } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackCriticalOperation('patient_data_sync', 1500, false);
 
@@ -174,8 +181,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackUserLogin', () => {
     it('should track successful user login', async () => {
-      const { setUser, setTag, captureMessage } =
-        await import('../config/sentry');
+      const { setUser, setTag, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackUserLogin('user_123', 'password', true);
 
@@ -192,8 +200,9 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed user login', async () => {
-      const { setUser, setTag, captureMessage } =
-        await import('../config/sentry');
+      const { setUser, setTag, captureMessage } = await import(
+        '../config/sentry'
+      );
 
       trackUserLogin('user_123', 'password', false);
 
@@ -229,8 +238,9 @@ describe('Sentry Utilities', () => {
 
   describe('trackReactError', () => {
     it('should track React error with component context', async () => {
-      const { setTag, setContext, captureException } =
-        await import('../config/sentry');
+      const { setTag, setContext, captureException } = await import(
+        '../config/sentry'
+      );
       const error = new Error('Component error');
       const errorInfo = { componentStack: 'Component stack trace' };
 

--- a/src/utils/sentry.test.ts
+++ b/src/utils/sentry.test.ts
@@ -26,9 +26,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackHealthWorkerAction', () => {
     it('should track health worker action with proper tags and context', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackHealthWorkerAction('patient_view', {
         patientId: '123',
@@ -50,9 +49,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackPatientInteraction', () => {
     it('should track patient interaction with proper tags and context', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackPatientInteraction('consultation', 'patient_123', {
         duration: 30,
@@ -75,9 +73,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackFormSubmission', () => {
     it('should track successful form submission', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackFormSubmission('patient_registration', true, {
         patientId: '123',
@@ -97,9 +94,8 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed form submission', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackFormSubmission('patient_registration', false, {
         patientId: '123',
@@ -121,9 +117,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackApiError', () => {
     it('should track API error with proper tags and context', async () => {
-      const { setTag, setContext, captureException } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureException } =
+        await import('../config/sentry');
       const error = new Error('API timeout');
 
       trackApiError('/api/patients', error, {
@@ -143,9 +138,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackCriticalOperation', () => {
     it('should track successful critical operation', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackCriticalOperation('patient_data_sync', 1500, true);
 
@@ -161,9 +155,8 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed critical operation', async () => {
-      const { setTag, setContext, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureMessage } =
+        await import('../config/sentry');
 
       trackCriticalOperation('patient_data_sync', 1500, false);
 
@@ -181,9 +174,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackUserLogin', () => {
     it('should track successful user login', async () => {
-      const { setUser, setTag, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setUser, setTag, captureMessage } =
+        await import('../config/sentry');
 
       trackUserLogin('user_123', 'password', true);
 
@@ -200,9 +192,8 @@ describe('Sentry Utilities', () => {
     });
 
     it('should track failed user login', async () => {
-      const { setUser, setTag, captureMessage } = await import(
-        '../config/sentry'
-      );
+      const { setUser, setTag, captureMessage } =
+        await import('../config/sentry');
 
       trackUserLogin('user_123', 'password', false);
 
@@ -238,9 +229,8 @@ describe('Sentry Utilities', () => {
 
   describe('trackReactError', () => {
     it('should track React error with component context', async () => {
-      const { setTag, setContext, captureException } = await import(
-        '../config/sentry'
-      );
+      const { setTag, setContext, captureException } =
+        await import('../config/sentry');
       const error = new Error('Component error');
       const errorInfo = { componentStack: 'Component stack trace' };
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Description

Follow-up to #10. Three things: the trigger changes you asked for, the fix for why reviews kept coming back empty, and repairing the Prettier breakage #10 introduced on `dev`.

### Triggers

`pull_request` on `[opened, reopened, ready_for_review, labeled]`, filtered to PRs whose **base** is `main` or `dev`. Plus `issue_comment` for `/review`.

**`synchronize` is gone.** Pushing follow-up commits to an open PR no longer re-reviews it, which keeps the free tier (50 requests/day, 4 per review) off work-in-progress. The cost is real: a review goes stale the moment the author pushes a fix, so a PR can carry a clean review of code that no longer exists. Two ways to ask for a fresh one:

- add the **`review-again`** label — removed automatically after the run so it can be reapplied
- comment **`/review`** — restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because without that gate any drive-by commenter could spend the day's budget

Both labels (`review-again`, `skip-review`) are created on the repo already.

Note `/review` will not work until this reaches `main` — GitHub runs `issue_comment` workflows from the default branch regardless of which branch defines them. The label and open/reopen paths work from a PR branch immediately. Since `dev` is where this is merging, the comment trigger stays dormant until `dev` reaches `main`.

Because `issue_comment` carries no branch context, the `branches:` filter cannot apply to it. The base branch is re-checked in the Resolve step so both entry points enforce the same rule.

### Why every review was empty

#10 fixed the 400s, but reviews still returned zero findings. Root cause: `listFreeModels` ranked candidates by **context length alone**. Of the 14 currently-free models, only 4 support structured outputs — and sorting by context put a 1M-context model with no such support at the head of the chain. It returned prose on every batch and the parser discarded all of it, then upstream 429s killed the repair attempts.

`rankModels` now sorts on structured-output support first, context second, extracted as a pure function so the ordering is under test (3 new cases, including the specific regression). `OPENROUTER_MODELS` is also pinned as a repo variable to the three capable models, so selection does not depend on what OpenRouter's free lineup looks like on any given day.

### Prettier

Merging #10 turned `prettier --check .` red on `dev` — the vendored package shipped in its own style and nothing had formatted it to this repo's config. Fixed by formatting the 13 files rather than adding a `.prettierignore`, since lint-staged reformats staged files on commit anyway and an ignore entry would just move the churn to whoever next edits a script. Verified the reflow did not disturb `sync-rules.mjs`'s parsing of `review-rules.md` — all 56 rules still resolve.

`src/utils/sentry.test.ts` was also failing `format:check`, unrelated to any of this. Fixed in its own commit so you can drop it if you would rather handle it separately.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- [x] Unit tests pass — 76, up from 73
- [x] `sync-rules.mjs --check` passes — 56 rules still in sync after reformatting
- [x] `prettier --check .` passes across the whole repo
- [x] Confirmed `synchronize` no longer fires — pushing `37471f1` to the #10 branch triggered no run
- [ ] Label and `/review` paths exercised on a live PR — worth doing on this one

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review completed
- [x] Documentation updated — README and `.github/review/README.md` both describe the new triggers and their tradeoff
- [x] No new dependencies

## Additional Notes

**Tuning is still weekly and still opens a PR rather than pushing** — unchanged. Worth holding off on merging any tuning PR while the agent only runs on this testbed: the rulebook is written for the wider Intelehealth stack, so SEC/DATA/API lean backend and will rarely fire on a React app. The loop cannot tell "this rule is useless" from "no applicable code here", so left alone it will happily mute good backend rules for lack of anything to fire on.

**The empty-review failure mode is worth remembering:** the workflow goes green either way. `openrouter-review.mjs` never exits non-zero by design, so a total provider failure and a clean review produce the same check mark. #10 added a summary line that says so explicitly when every batch fails — read the comment body, not the tick.
