### PR TITLE
test: verify the blocking merge gate (DO NOT MERGE)

### DIFF
--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -6,31 +6,36 @@ rules people keep dismissing.
 
 ## When it runs
 
-On a PR **into `main` or `dev`** — PRs targeting anything else are not reviewed
-— when it is opened, reopened, marked ready for review, **or pushed to**. Plus,
-on demand:
+**The model only runs when somebody asks for it.** Opening a PR or pushing to
+one costs nothing. Ask by adding the **`review-again`** label, or by commenting
+**`/review`**.
 
-- Someone adds the **`review-again`** label. It is removed again afterwards so
-  it can be reapplied.
-- Someone with write access comments **`/review`**.
+The check, however, reports on every `pull_request` event, because it is a
+required check and a required check that never reports leaves a PR unmergeable
+forever:
 
-`synchronize` is included because this check blocks merges. A developer has to
-be able to clear a red review by pushing the fix; a blocking check with no
-obvious way to turn it green is how teams learn to route around a gate. The
-cost is budget — every push to an open PR spends up to 4 OpenRouter requests
-against a 50/day free tier. If that starts to bite, drop `synchronize` from the
-workflow and rely on the label, or top the account up.
+| Event                             | Check                         | Requests |
+| --------------------------------- | ----------------------------- | -------- |
+| PR opened / reopened / ready      | 🔴 review not requested       | 0        |
+| Push to an open PR                | 🔴 code changed               | 0        |
+| `review-again` label or `/review` | 🔴 on findings, 🟢 when clean | ≤ 4      |
+| Draft, `skip-review`, other base  | 🟢 gate bypassed              | 0        |
 
-Every `pull_request` event runs the job, even ones that will do no work. That
-is deliberate: a required check which never reports leaves a PR unmergeable
-forever, so drafts, `skip-review`, and unrelated labels are handled _inside_
-the job, which exits cleanly and lets the check go green.
+**A push always sends the check back to red.** That is the point: a review
+which passed against code you have since changed must not keep the merge
+unblocked. Ask for a fresh one after pushing.
 
-Two caveats on the comment trigger. GitHub runs `issue_comment` workflows from
-the **default branch**, so `/review` only works once this workflow is merged to
-`main` — the other triggers work from a PR branch straight away. And `/review`
-is restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because without that gate any
-drive-by commenter could spend the day's request budget.
+`skip-review` bypasses the gate entirely and is the deliberate escape hatch.
+
+`/review` does not review directly — it adds the label, and the `labeled` event
+does the work. GitHub associates an `issue_comment` workflow run with the
+**default branch** rather than the PR head, so a check published from one would
+never attach to the PR; routing through the label keeps a single code path with
+the correct commit association. It also means `/review` only works once this
+workflow reaches `main`, while the label works from a PR branch straight away.
+
+`/review` is restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because without
+that gate any drive-by commenter could spend the day's request budget.
 
 ## How it works
 

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -1,28 +1,36 @@
-# Claude PR review agent
+# IH Tek PR review agent
 
-An automated pull request reviewer that applies a written rulebook and gets
-quieter over time about the rules people keep dismissing.
+An automated pull request reviewer that applies a written rulebook, blocks the
+merge while it has findings against a PR, and gets quieter over time about the
+rules people keep dismissing.
 
 ## When it runs
 
-- A PR **into `main` or `dev`** is opened, reopened, or marked ready for review.
-  PRs targeting anything else are not reviewed.
-- Someone adds the **`review-again`** label to such a PR. The label is removed
-  again afterwards so it can be reapplied.
-- Someone with write access comments **`/review`** on it.
+On a PR **into `main` or `dev`** — PRs targeting anything else are not reviewed
+— when it is opened, reopened, marked ready for review, **or pushed to**. Plus,
+on demand:
 
-Deliberately **not** on `synchronize`. Pushing follow-up commits to an open PR
-does not re-review it, which keeps the free tier from being spent on
-work-in-progress. The cost is real and worth stating plainly: a review goes
-stale the moment the author pushes a fix, so a PR can carry a clean review of
-code that no longer exists. Re-request it with the label or the comment when the
-diff has moved enough to matter.
+- Someone adds the **`review-again`** label. It is removed again afterwards so
+  it can be reapplied.
+- Someone with write access comments **`/review`**.
+
+`synchronize` is included because this check blocks merges. A developer has to
+be able to clear a red review by pushing the fix; a blocking check with no
+obvious way to turn it green is how teams learn to route around a gate. The
+cost is budget — every push to an open PR spends up to 4 OpenRouter requests
+against a 50/day free tier. If that starts to bite, drop `synchronize` from the
+workflow and rely on the label, or top the account up.
+
+Every `pull_request` event runs the job, even ones that will do no work. That
+is deliberate: a required check which never reports leaves a PR unmergeable
+forever, so drafts, `skip-review`, and unrelated labels are handled _inside_
+the job, which exits cleanly and lets the check go green.
 
 Two caveats on the comment trigger. GitHub runs `issue_comment` workflows from
 the **default branch**, so `/review` only works once this workflow is merged to
-`main` — the label and the open/reopen triggers work from a PR branch straight
-away. And `/review` is restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because
-without that gate any drive-by commenter could spend the day's request budget.
+`main` — the other triggers work from a PR branch straight away. And `/review`
+is restricted to `OWNER`/`MEMBER`/`COLLABORATOR`, because without that gate any
+drive-by commenter could spend the day's request budget.
 
 ## How it works
 
@@ -38,13 +46,15 @@ Once triggered, a review is three steps:
    accept, and posts one review.
 
 Step 2 is the only provider-specific part. Anything that writes
-`findings.json` in the schema below works — the shipped alternative is
-`workflows/claude-pr-review.yml`, which uses `anthropics/claude-code-action@v1`
-and can read the surrounding source rather than only the diff. Swapping
-providers does not touch the rulebook, the gating, or the feedback loop.
+`findings.json` in the schema below works, so swapping providers does not touch
+the rulebook, the gating, or the feedback loop. The upstream package also
+shipped a `claude-pr-review.yml` using `anthropics/claude-code-action@v1`, which
+can read the surrounding source rather than only the diff; it was removed here
+in favour of OpenRouter, and is worth revisiting if the diff-only limits below
+prove too costly.
 
-The split between step 2 and step 3 is the whole design. Claude decides _what_
-is wrong; the script decides _what gets said_. That keeps the comment cap, the
+The split between step 2 and step 3 is the whole design. The model decides
+_what is wrong_; the script decides _what gets said_. That keeps the comment cap, the
 confidence thresholds, and the mute list as code rather than as polite requests
 in a prompt, and it means every posted comment carries a machine-readable
 marker tying it back to a rule.
@@ -232,11 +242,30 @@ node --test .github/review/scripts/test/*.test.mjs
 
 ## Deliberate limits
 
-**It never blocks a merge.** The review posts as `COMMENT`, and
-`post-review.mjs` exits zero even when it fails. Set
-`REQUEST_CHANGES_ON_BLOCKER: "1"` in the workflow if you want blockers to
-request changes — but note that a review from `GITHUB_TOKEN` does not satisfy a
-branch protection "required approvals" rule either way.
+**It blocks the merge when it finds something.** `post-review.mjs` exits
+non-zero while any finding stands, which fails the check; with branch
+protection requiring that check, the PR cannot merge. `BLOCK_MIN_SEVERITY`
+controls how severe a finding has to be to count — the default, `nit`, means
+anything at all. `BLOCK_ON_FINDINGS: '0'` makes the reviewer advisory again.
+
+Two properties of the gate are worth understanding, because they are what stop
+it becoming something people route around:
+
+- **Only findings block. Reviewer failures never do.** No API key, no diff,
+  unreadable output, provider outage, exhausted budget — all exit zero. A bad
+  day at OpenRouter must not be the reason nobody on the team can merge.
+- **The gate reasons about the code, not about the comments.** The blocking
+  decision is recomputed from every current finding, ignoring which ones earlier
+  runs already posted. Otherwise a second run on an unchanged PR would find
+  nothing "new" to say and let it through with every problem intact.
+
+Clearing a red review means pushing the fix (the check re-runs on
+`synchronize`), or re-requesting with the `review-again` label. `skip-review`
+bypasses the gate entirely and is the deliberate escape hatch.
+
+Note that a review posted by `GITHUB_TOKEN` does not satisfy a branch
+protection "required approvals" rule — the gate here is the _check_, not the
+review verdict, which is why `REQUEST_CHANGES_ON_BLOCKER` is not the mechanism.
 
 **Fork PRs on public repositories are skipped.** GitHub withholds secrets from
 those runs, so the review step cannot authenticate. This is a GitHub security

--- a/.github/review/README.md
+++ b/.github/review/README.md
@@ -247,18 +247,28 @@ node --test .github/review/scripts/test/*.test.mjs
 
 ## Deliberate limits
 
-**It blocks the merge when it finds something.** `post-review.mjs` exits
-non-zero while any finding stands, which fails the check; with branch
-protection requiring that check, the PR cannot merge. `BLOCK_MIN_SEVERITY`
+**It blocks the merge when it finds something — or when it could not look.**
+`post-review.mjs` exits non-zero while any finding stands, and also when the
+review did not actually complete; with branch protection requiring that check,
+the PR cannot merge. `BLOCK_MIN_SEVERITY`
 controls how severe a finding has to be to count — the default, `nit`, means
 anything at all. `BLOCK_ON_FINDINGS: '0'` makes the reviewer advisory again.
 
 Two properties of the gate are worth understanding, because they are what stop
 it becoming something people route around:
 
-- **Only findings block. Reviewer failures never do.** No API key, no diff,
-  unreadable output, provider outage, exhausted budget — all exit zero. A bad
-  day at OpenRouter must not be the reason nobody on the team can merge.
+- **An unread diff never reads as clean.** An empty findings array means one
+  of two very different things: the code is clean, or the model gave up. Those
+  are indistinguishable to branch protection, so the generator records whether
+  it actually engaged — batches failed, files dropped for budget, a summary
+  admitting it saw no code, or unparseable output followed by nothing — and an
+  incomplete review fails the check with a different message from a review that
+  found problems. Observed in practice: a PR here went green on
+  `No code was provided for review.` before this existed.
+  `REQUIRE_COMPLETE_REVIEW: '0'` restores the older, more forgiving behaviour.
+  The cost is that a provider outage holds merges until someone re-requests a
+  review or applies `skip-review` — an explicit, visible escape hatch rather
+  than a silent pass.
 - **The gate reasons about the code, not about the comments.** The blocking
   decision is recomputed from every current finding, ignoring which ones earlier
   runs already posted. Otherwise a second run on an unchanged PR would find

--- a/.github/review/scripts/lib/openrouter.mjs
+++ b/.github/review/scripts/lib/openrouter.mjs
@@ -209,11 +209,13 @@ export function rankModels(models) {
 }
 
 /**
- * Fetch the models that are currently free, best first.
+ * Fetch every model OpenRouter offers, best first, each with a `free` flag.
+ * Fetching is not the spending decision — chooseModels is.
+ *
  * @param {string} apiKey
- * @returns {Promise<Array<{id:string, context:number, structured:boolean}>>}
+ * @returns {Promise<Array<{id:string, context:number, structured:boolean, free:boolean}>>}
  */
-export async function listFreeModels(apiKey) {
+export async function listModels(apiKey) {
   const res = await fetch(`${BASE}/models`, {
     headers: { authorization: `Bearer ${apiKey}` },
   });
@@ -225,13 +227,17 @@ export async function listFreeModels(apiKey) {
 
   return rankModels(
     (data || [])
-      .filter(m => typeof m.id === 'string' && m.id.endsWith(':free'))
+      .filter(m => typeof m.id === 'string')
       .map(m => ({
         id: m.id,
         context: Number(m.context_length) || 0,
         structured: (m.supported_parameters || []).includes(
           'structured_outputs'
         ),
+        free:
+          m.id.endsWith(':free') ||
+          (Number(m.pricing?.prompt) === 0 &&
+            Number(m.pricing?.completion) === 0),
       }))
   );
 }
@@ -245,9 +251,9 @@ export const MAX_FALLBACK_MODELS = 3;
 /**
  * Choose the model chain to send.
  *
- * `preferred` wins where those models are actually available today; anything
- * still free is appended as a fallback so a retired model degrades into a
- * slightly worse review rather than a red workflow.
+ * `preferred` wins whether the model is free or paid — naming a paid model is
+ * the explicit decision to spend. Auto-filled fallbacks are free only, so a
+ * repository that pins nothing can never start billing by itself.
  *
  * @param {Array<{id:string, context:number, structured:boolean}>} available
  * @param {string[]} preferred
@@ -263,7 +269,8 @@ export function chooseModels(
   for (const id of preferred) {
     if (byId.has(id)) chain.push(byId.get(id));
   }
-  for (const m of available) {
+  // Only free models auto-fill. Paid ones must be named.
+  for (const m of available.filter(m => m.free !== false)) {
     if (chain.length >= limit) break;
     if (!chain.some(c => c.id === m.id)) chain.push(m);
   }

--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -192,6 +192,8 @@ async function main() {
     writeFindings({
       summary: 'Review skipped: no OpenRouter API key configured.',
       findings: [],
+      reviewed: false,
+      inconclusive: 'no OpenRouter API key is configured',
     });
     return;
   }
@@ -200,6 +202,8 @@ async function main() {
     writeFindings({
       summary: 'Review skipped: no diff was produced.',
       findings: [],
+      reviewed: false,
+      inconclusive: 'the diff could not be produced',
     });
     return;
   }
@@ -209,6 +213,7 @@ async function main() {
     writeFindings({
       summary: 'No reviewable changes in this pull request.',
       findings: [],
+      reviewed: true,
     });
     return;
   }
@@ -233,6 +238,8 @@ async function main() {
     writeFindings({
       summary: `Review skipped: OpenRouter unreachable (${err.message}).`,
       findings: [],
+      reviewed: false,
+      inconclusive: `OpenRouter was unreachable (${err.message})`,
     });
     return;
   }
@@ -240,6 +247,8 @@ async function main() {
     writeFindings({
       summary: 'Review skipped: no free models are currently available.',
       findings: [],
+      reviewed: false,
+      inconclusive: 'no free models were available',
     });
     return;
   }
@@ -290,6 +299,7 @@ async function main() {
   const debug = [];
   const seen = new Set();
   let failures = 0;
+  let repaired = 0;
 
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i];
@@ -326,6 +336,7 @@ async function main() {
       console.log(
         `Batch ${i + 1}: unparseable reply from ${result.model}, retrying once.`
       );
+      repaired++;
       await sleep(REQUEST_SPACING_MS);
       try {
         const repair = await complete({
@@ -409,7 +420,39 @@ async function main() {
     [summaries.join(' '), notes.join(' ')].filter(Boolean).join('\n\n') ||
     'No reviewable findings were produced.';
 
-  writeFindings({ summary, findings: all });
+  // --- did the model actually read this diff? -----------------------------
+  //
+  // An empty findings array means one of two very different things: the code
+  // is clean, or the model gave up and said so politely. Those are
+  // indistinguishable downstream, and treating the second as a pass is how an
+  // unreviewed PR sails through a merge gate. Anything short of a complete
+  // read is reported as inconclusive rather than clean.
+  const GAVE_UP =
+    /\bno code (was )?(provided|supplied|given)|\bnothing (was )?(provided|supplied)|\bunable to review|\bcannot review|\bno (diff|changes|content) (was |were )?(provided|supplied|given)/i;
+
+  let inconclusive = null;
+  if (failures === chunks.length) {
+    inconclusive = `all ${chunks.length} batch(es) failed`;
+  } else if (failures) {
+    inconclusive = `${failures} of ${chunks.length} batch(es) failed, so part of the diff was never read`;
+  } else if (skipped.length) {
+    inconclusive = `${skipped.length} file(s) exceeded the ${MAX_REQUESTS}-request budget and were never read: ${skipped.join(', ')}`;
+  } else if (all.length === 0 && GAVE_UP.test(summaries.join(' '))) {
+    inconclusive = 'the model reported that it did not see the code';
+  } else if (all.length === 0 && repaired > 0) {
+    inconclusive = `${repaired} batch(es) returned unparseable output and then found nothing, which usually means the model did not engage with the diff`;
+  }
+
+  if (inconclusive) {
+    console.log(`Review is inconclusive: ${inconclusive}.`);
+  }
+
+  writeFindings({
+    summary,
+    findings: all,
+    reviewed: !inconclusive,
+    ...(inconclusive ? { inconclusive } : {}),
+  });
   writeFileSync(
     DEBUG_PATH,
     JSON.stringify({ chain: chain.map(m => m.id), debug }, null, 2)

--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -26,7 +26,7 @@ import {
   estimateTokens,
   extractJson,
   keyStatus,
-  listFreeModels,
+  listModels,
   MAX_FALLBACK_MODELS,
   packChunks,
   splitDiffByFile,
@@ -232,7 +232,7 @@ async function main() {
   // --- pick models --------------------------------------------------------
   let available;
   try {
-    available = await listFreeModels(API_KEY);
+    available = await listModels(API_KEY);
   } catch (err) {
     console.error(`Could not list models: ${err.message}`);
     writeFindings({
@@ -245,10 +245,10 @@ async function main() {
   }
   if (available.length === 0) {
     writeFindings({
-      summary: 'Review skipped: no free models are currently available.',
+      summary: 'Review skipped: no usable models are currently available.',
       findings: [],
       reviewed: false,
-      inconclusive: 'no free models were available',
+      inconclusive: 'no usable models were available',
     });
     return;
   }

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -13,8 +13,9 @@
  *   - a line outside the diff cannot 422 the whole review and lose the rest of
  *     the comments with it.
  *
- * Never exits non-zero for review content. A broken reviewer must not break
- * anyone's CI.
+ * Exits non-zero when the PR should not merge: either findings stand against
+ * it, or the review did not actually complete. Both are deliberate — see
+ * BLOCK_ON_FINDINGS and REQUIRE_COMPLETE_REVIEW below.
  */
 
 import { readFileSync, existsSync, writeFileSync } from 'node:fs';
@@ -45,14 +46,28 @@ const REQUEST_CHANGES_ON_BLOCKER =
  * When set, unresolved findings make this script exit non-zero, which fails the
  * check and — with branch protection requiring it — blocks the merge.
  *
- * Only findings do this. Every infrastructure failure path (no API key, no
- * diff, unreadable findings.json, a thrown error) still exits zero, because a
- * provider outage must never be the reason nobody on the team can merge.
+ * This covers findings specifically. A review that never ran is handled by
+ * REQUIRE_COMPLETE_REVIEW below — the two are separate because they mean
+ * different things to whoever has to clear the check.
  */
 const BLOCK_ON_FINDINGS = process.env.BLOCK_ON_FINDINGS !== '0';
 
 /** Least severe finding that still blocks. Default: anything at all. */
 const BLOCK_MIN_SEVERITY = process.env.BLOCK_MIN_SEVERITY || 'nit';
+
+/**
+ * When set, a review that did not actually complete fails the check too.
+ *
+ * Without this, a model that returns a well-formed empty result — because it
+ * gave up, or because half the diff never fit in the budget — is
+ * indistinguishable from a genuinely clean review, and quietly unblocks the
+ * merge. A gate that green-lights unread code is not a gate.
+ *
+ * The cost is that a provider outage holds merges until someone re-requests a
+ * review or applies `skip-review`. That is the deliberate trade: the escape
+ * hatch is explicit and visible, rather than a silent pass.
+ */
+const REQUIRE_COMPLETE_REVIEW = process.env.REQUIRE_COMPLETE_REVIEW !== '0';
 
 const SEVERITY_LABEL = {
   blocker: '🔴 Blocker',
@@ -208,6 +223,7 @@ async function main() {
     console.log(
       'No findings.json was produced — the review step likely failed. Nothing to post.'
     );
+    failIncomplete('the review step produced no output at all');
     return;
   }
 
@@ -216,8 +232,17 @@ async function main() {
     payload = JSON.parse(readFileSync(FINDINGS_PATH, 'utf8'));
   } catch (err) {
     console.error(`findings.json is not valid JSON: ${err.message}`);
+    failIncomplete('the review step produced unreadable output');
     return;
   }
+
+  // An explicit false means the generator knows it did not read the whole
+  // diff. Absent (an older findings.json) is treated as reviewed, so this
+  // cannot retroactively block PRs written before the flag existed.
+  const incomplete =
+    payload.reviewed === false
+      ? payload.inconclusive || 'the review did not complete'
+      : null;
 
   const book = JSON.parse(readFileSync(RULES_PATH, 'utf8'));
   const rules = book.rules;
@@ -323,7 +348,7 @@ async function main() {
   // Nothing new to say and nothing already said: stay quiet.
   if (inline.length === 0 && outOfDiff.length === 0 && alreadyPosted.size > 0) {
     console.log('No new findings since the last run. Not posting.');
-    applyMergeGate(blocking);
+    applyMergeGate(blocking, incomplete);
     return;
   }
 
@@ -367,7 +392,7 @@ async function main() {
     }
   }
 
-  applyMergeGate(blocking);
+  applyMergeGate(blocking, incomplete);
 }
 
 /**
@@ -376,7 +401,33 @@ async function main() {
  * Sets exitCode rather than calling process.exit so the review that was just
  * posted is not lost to an early teardown.
  */
-function applyMergeGate(blocking) {
+function failIncomplete(reason) {
+  if (!REQUIRE_COMPLETE_REVIEW) {
+    console.log(
+      `Review incomplete (${reason}), but REQUIRE_COMPLETE_REVIEW is off.`
+    );
+    return;
+  }
+  console.error(`\nThe review did not complete: ${reason}.`);
+  console.error(
+    'An absence of findings therefore does not mean this code is clean — it ' +
+      'means it was not read. Re-request a review with the `review-again` ' +
+      'label, or add `skip-review` to merge without one.'
+  );
+  process.exitCode = 1;
+}
+
+function applyMergeGate(blocking, incomplete) {
+  if (incomplete) {
+    // Report the findings we did get, then fail for the ones we may not have.
+    if (blocking.length) {
+      console.error(
+        `${blocking.length} finding(s) posted before the review ran out.`
+      );
+    }
+    failIncomplete(incomplete);
+    return;
+  }
   if (!blocking.length) {
     console.log('No unresolved findings. Merge gate is clear.');
     return;

--- a/.github/review/scripts/post-review.mjs
+++ b/.github/review/scripts/post-review.mjs
@@ -41,6 +41,19 @@ const DIFF_TRUNCATED = process.env.DIFF_TRUNCATED === 'true';
 const REQUEST_CHANGES_ON_BLOCKER =
   process.env.REQUEST_CHANGES_ON_BLOCKER === '1';
 
+/**
+ * When set, unresolved findings make this script exit non-zero, which fails the
+ * check and — with branch protection requiring it — blocks the merge.
+ *
+ * Only findings do this. Every infrastructure failure path (no API key, no
+ * diff, unreadable findings.json, a thrown error) still exits zero, because a
+ * provider outage must never be the reason nobody on the team can merge.
+ */
+const BLOCK_ON_FINDINGS = process.env.BLOCK_ON_FINDINGS !== '0';
+
+/** Least severe finding that still blocks. Default: anything at all. */
+const BLOCK_MIN_SEVERITY = process.env.BLOCK_MIN_SEVERITY || 'nit';
+
 const SEVERITY_LABEL = {
   blocker: '🔴 Blocker',
   major: '🟠 Major',
@@ -244,6 +257,21 @@ async function main() {
     `${kept.length} finding(s) passed the gate, ${dropped.length} dropped.`
   );
 
+  // What is wrong with this PR *right now*, independent of what earlier runs
+  // already said. `kept` excludes anything already posted, so a re-run where
+  // every problem still stands would otherwise look clean and let the merge
+  // through. The merge decision has to be about the code, not about which
+  // comments happen to be new.
+  const { kept: unresolved } = gateFindings(valid, rules, {
+    prNumber: PR_NUMBER,
+    maxComments: book.defaults?.maxCommentsPerPR ?? 12,
+    explorationPercent: book.defaults?.explorationPercent ?? 10,
+    alreadyPosted: new Set(),
+  });
+  const blocking = unresolved.filter(
+    f => SEVERITY_ORDER[f.severity] <= SEVERITY_ORDER[BLOCK_MIN_SEVERITY]
+  );
+
   // --- map to lines GitHub will accept ------------------------------------
   const files = await getPullFiles(REPO, PR_NUMBER);
   const lineIndex = new Map();
@@ -295,6 +323,7 @@ async function main() {
   // Nothing new to say and nothing already said: stay quiet.
   if (inline.length === 0 && outOfDiff.length === 0 && alreadyPosted.size > 0) {
     console.log('No new findings since the last run. Not posting.');
+    applyMergeGate(blocking);
     return;
   }
 
@@ -337,6 +366,41 @@ async function main() {
       console.error(`Fallback comment also failed: ${err2.message}`);
     }
   }
+
+  applyMergeGate(blocking);
+}
+
+/**
+ * Fail the check when the PR still has findings against it.
+ *
+ * Sets exitCode rather than calling process.exit so the review that was just
+ * posted is not lost to an early teardown.
+ */
+function applyMergeGate(blocking) {
+  if (!blocking.length) {
+    console.log('No unresolved findings. Merge gate is clear.');
+    return;
+  }
+  const counts = {};
+  for (const f of blocking) counts[f.severity] = (counts[f.severity] || 0) + 1;
+  const breakdown = Object.entries(counts)
+    .map(([sev, n]) => `${n} ${sev}`)
+    .join(', ');
+
+  if (!BLOCK_ON_FINDINGS) {
+    console.log(`${blocking.length} unresolved finding(s) (${breakdown}).`);
+    console.log('BLOCK_ON_FINDINGS is off, so this does not fail the check.');
+    return;
+  }
+
+  console.error(
+    `\n${blocking.length} unresolved finding(s) on this pull request: ${breakdown}.`
+  );
+  console.error(
+    'Address them, then re-request a review with the `review-again` label ' +
+      'or a `/review` comment. To merge anyway, add the `skip-review` label.'
+  );
+  process.exitCode = 1;
 }
 
 main().catch(err => {

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -75,20 +75,32 @@ async function runPostReview(findings, stub, env = {}) {
       typeof findings === 'string' ? findings : JSON.stringify(findings)
     );
   }
-  const { stdout, stderr } = await run(process.execPath, [SCRIPT], {
-    cwd: dir,
-    env: {
-      ...process.env,
-      GITHUB_API_URL: `http://127.0.0.1:${stub.port}`,
-      GITHUB_TOKEN: 'stub-token',
-      REPO: 'acme/app',
-      PR_NUMBER: '7',
-      HEAD_SHA: 'deadbeef',
-      ...env,
-    },
-  });
+  // execFile rejects on a non-zero exit, and a non-zero exit is now a normal
+  // outcome — it is how the merge gate reports unresolved findings. Capture the
+  // code instead of letting it throw.
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    ({ stdout, stderr } = await run(process.execPath, [SCRIPT], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        GITHUB_API_URL: `http://127.0.0.1:${stub.port}`,
+        GITHUB_TOKEN: 'stub-token',
+        REPO: 'acme/app',
+        PR_NUMBER: '7',
+        HEAD_SHA: 'deadbeef',
+        BLOCK_ON_FINDINGS: '0',
+        ...env,
+      },
+    }));
+  } catch (err) {
+    ({ stdout = '', stderr = '' } = err);
+    exitCode = err.code ?? 1;
+  }
   await rm(dir, { recursive: true, force: true });
-  return { stdout, stderr };
+  return { stdout, stderr, exitCode };
 }
 
 const findingsPayload = findings => ({
@@ -223,6 +235,103 @@ test('invalid JSON and a missing file are both survivable', async () => {
       const { stdout, stderr } = await runPostReview(input, stub);
       assert.equal(stub.requests.filter(r => r.method === 'POST').length, 0);
       assert.ok(/not valid JSON|No findings.json/.test(stdout + stderr));
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+// --- merge gate ------------------------------------------------------------
+
+test('unresolved findings fail the check so the merge is blocked', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode, stderr } = await runPostReview(
+      findingsPayload([base]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 1, 'a finding must fail the check');
+    assert.match(stderr, /1 unresolved finding\(s\)/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a clean PR does not block the merge', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode, stdout } = await runPostReview(
+      findingsPayload([]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 0);
+    assert.match(stdout, /Merge gate is clear/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('findings already posted still block on a re-run', async () => {
+  // The regression this guards: `kept` excludes anything a previous run already
+  // commented on, so gating on it would let a PR whose every problem still
+  // stands sail through the second time it is checked.
+  const existing = [
+    {
+      id: 100,
+      body:
+        'old\n<!-- ih-tek-review rule=SEC-001 fid=' +
+        (await import('../lib/scoring.mjs')).findingId(base) +
+        ' -->',
+    },
+  ];
+  const stub = await startStub({ existingComments: existing });
+  try {
+    const { exitCode, stdout } = await runPostReview(
+      findingsPayload([base]),
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.match(stdout, /No new findings since the last run/);
+    assert.equal(
+      exitCode,
+      1,
+      'the problem still exists, so it must still block'
+    );
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('BLOCK_MIN_SEVERITY lets nits through while majors still block', async () => {
+  for (const [severity, expected] of [
+    ['nit', 0],
+    ['major', 1],
+  ]) {
+    const stub = await startStub();
+    try {
+      const { exitCode } = await runPostReview(
+        findingsPayload([{ ...base, severity, confidence: 0.95 }]),
+        stub,
+        { BLOCK_ON_FINDINGS: '1', BLOCK_MIN_SEVERITY: 'major' }
+      );
+      assert.equal(exitCode, expected, `severity ${severity}`);
+    } finally {
+      stub.server.close();
+    }
+  }
+});
+
+test('a broken reviewer never blocks the merge', async () => {
+  // A provider outage must not be the reason nobody on the team can merge.
+  for (const input of ['{ not json', null]) {
+    const stub = await startStub();
+    try {
+      const { exitCode } = await runPostReview(input, stub, {
+        BLOCK_ON_FINDINGS: '1',
+      });
+      assert.equal(exitCode, 0, 'infrastructure failure must not block');
     } finally {
       stub.server.close();
     }

--- a/.github/review/scripts/test/post-review.e2e.test.mjs
+++ b/.github/review/scripts/test/post-review.e2e.test.mjs
@@ -323,18 +323,86 @@ test('BLOCK_MIN_SEVERITY lets nits through while majors still block', async () =
   }
 });
 
-test('a broken reviewer never blocks the merge', async () => {
-  // A provider outage must not be the reason nobody on the team can merge.
+// --- incomplete reviews ----------------------------------------------------
+
+test('a review that did not complete does not pass the gate', async () => {
+  // The hole this closes: a model that returns a well-formed empty result
+  // because it gave up looks identical to a genuinely clean review, and would
+  // otherwise unblock the merge on code nothing ever read.
+  const stub = await startStub();
+  try {
+    const { exitCode, stderr } = await runPostReview(
+      {
+        summary: 'No code was provided for review.',
+        findings: [],
+        reviewed: false,
+        inconclusive: 'the model reported that it did not see the code',
+      },
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 1, 'an unread diff must not read as clean');
+    assert.match(stderr, /did not complete/);
+    assert.match(stderr, /did not see the code/);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a completed clean review still passes', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(
+      { summary: 'Looks fine.', findings: [], reviewed: true },
+      stub,
+      { BLOCK_ON_FINDINGS: '1' }
+    );
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('findings.json without the flag is treated as reviewed', async () => {
+  // Older output has no `reviewed` key. Absent must not mean "incomplete", or
+  // upgrading would retroactively block every open PR.
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(findingsPayload([]), stub, {
+      BLOCK_ON_FINDINGS: '1',
+    });
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
+  }
+});
+
+test('a missing or unreadable findings.json blocks rather than passes', async () => {
   for (const input of ['{ not json', null]) {
     const stub = await startStub();
     try {
-      const { exitCode } = await runPostReview(input, stub, {
+      const { exitCode, stderr } = await runPostReview(input, stub, {
         BLOCK_ON_FINDINGS: '1',
       });
-      assert.equal(exitCode, 0, 'infrastructure failure must not block');
+      assert.equal(exitCode, 1, 'no output means nothing was reviewed');
+      assert.match(stderr, /did not complete/);
     } finally {
       stub.server.close();
     }
+  }
+});
+
+test('REQUIRE_COMPLETE_REVIEW=0 restores the advisory behaviour', async () => {
+  const stub = await startStub();
+  try {
+    const { exitCode } = await runPostReview(
+      { summary: 'gave up', findings: [], reviewed: false },
+      stub,
+      { BLOCK_ON_FINDINGS: '1', REQUIRE_COMPLETE_REVIEW: '0' }
+    );
+    assert.equal(exitCode, 0);
+  } finally {
+    stub.server.close();
   }
 });
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,29 +2,33 @@ name: PR Review
 
 # Automated PR review using OpenRouter free models.
 #
-# Three steps — prepare the diff, generate findings, post them. post-review.mjs,
-# the rule gating and the feedback loop are provider-agnostic: only the middle
-# step knows it is talking to OpenRouter.
+# The model only runs when somebody asks for it — by adding the `review-again`
+# label, or by commenting `/review`. Opening a PR or pushing to one costs
+# nothing.
 #
-# When this runs:
-#   - a PR into main or dev is opened, reopened, marked ready for review, or
-#     pushed to
-#   - someone adds the `review-again` label to such a PR
-#   - someone with write access comments `/review` on it
+# But the check still reports on every pull_request event, because it is a
+# REQUIRED check and a required check that never reports leaves a PR
+# unmergeable forever. So:
 #
-# This check BLOCKS merges: unresolved findings fail it, and branch protection
-# requires it. Only findings do that — every reviewer failure path still exits
-# zero, so a provider outage cannot stop the team merging.
+#   PR opened / reopened / ready   -> check RED  "review not requested"   0 requests
+#   push to an open PR             -> check RED  "code changed"           0 requests
+#   `review-again` label / /review -> full review, RED on findings        <=4 requests
+#                                     or GREEN when clean
+#   draft / skip-review / other base -> check GREEN, gate bypassed        0 requests
+#
+# A push always sends the check back to red. That is the point: a review that
+# passed against code which has since changed must not keep a merge unblocked.
+#
+# `/review` does not review directly — it adds the label. GitHub associates an
+# issue_comment workflow run with the default branch rather than the PR head, so
+# a check published from one would never attach to the PR. Going through the
+# label keeps a single code path with the correct commit association.
 
 on:
   pull_request:
-    # `synchronize` is here because this check BLOCKS merges. A developer has to
-    # be able to clear a failing review by pushing the fix; without it the only
-    # way out is the label, and a red check with no obvious way to make it green
-    # is how teams learn to route around a gate.
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     # Base branch, i.e. what the PR merges INTO. PRs targeting anything else
-    # (qa, staging, feature branches) are not reviewed.
+    # (qa, staging, feature branches) are not reviewed and are not gated.
     branches: [main, dev]
   issue_comment:
     types: [created]
@@ -34,22 +38,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  review:
-    # Every pull_request event runs this job, even the ones that will do no
-    # work. That is deliberate: this is a REQUIRED check, and a required check
-    # that never reports leaves a PR unmergeable forever. Drafts, `skip-review`,
-    # and unrelated labels are therefore handled inside Resolve, which exits
-    # cleanly and lets the check go green, rather than skipping the job.
-    #
-    # `/review` is restricted to people with write access. Without that gate any
-    # drive-by commenter could burn the day's request budget.
+  # `/review` on a pull request just applies the label. The labeled event then
+  # does the real work below.
+  request:
     if: >
-      github.event_name == 'pull_request' || (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/review') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      )
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Request a review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh api -X POST \
+            "repos/${REPO}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes --silent || true
+          gh issue edit "$NUMBER" --repo "$REPO" --add-label review-again
+          echo "Requested a review on #${NUMBER} via the review-again label."
+
+  review:
+    # Every pull_request event runs this job, including the ones that do no
+    # work. A required check must always report, or the PR can never merge.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -58,95 +77,66 @@ jobs:
       issues: write
 
     steps:
-      - name: Resolve pull request
+      - name: Decide what this run should do
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          EVENT: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           LABEL_NAME: ${{ github.event.label.name }}
-          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          if [ "$EVENT" = "pull_request" ]; then
-            NUMBER="$PR_FROM_EVENT"
-          else
-            NUMBER="$ISSUE_NUMBER"
-          fi
-
-          # A label event for any label other than review-again is not a review
-          # request. Report green and spend nothing.
-          if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" != "review-again" ]; then
-            echo "Labeled '${LABEL_NAME}', not a review request. Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-
-          # Read head/base from the API rather than the event payload so both
-          # entry points agree, and so a comment made minutes ago still resolves
-          # to the PR's current head.
           DATA=$(gh pr view "$NUMBER" --repo "$REPO" \
             --json headRefOid,baseRefOid,baseRefName,isDraft,labels,state)
 
           BASE_REF=$(echo "$DATA" | jq -r .baseRefName)
           IS_DRAFT=$(echo "$DATA" | jq -r .isDraft)
           STATE=$(echo "$DATA" | jq -r .state)
-          SKIP=$(echo "$DATA" | jq -r '[.labels[].name] | index("skip-review") // "" ')
+          SKIP=$(echo "$DATA" | jq -r '[.labels[].name] | index("skip-review") // ""')
 
-          # The `branches:` filter does not apply to issue_comment, so enforce
-          # the same rule here for the comment path.
-          if [ "$BASE_REF" != "main" ] && [ "$BASE_REF" != "dev" ]; then
-            echo "PR #${NUMBER} targets '${BASE_REF}', not main or dev. Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          if [ "$STATE" != "OPEN" ]; then
-            echo "PR #${NUMBER} is ${STATE}. Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "PR #${NUMBER} is a draft. Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
-          fi
-          if [ -n "$SKIP" ]; then
-            echo "PR #${NUMBER} carries skip-review. Skipping."
-            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+          # --- bypass: report green, spend nothing -----------------------------
+          if [ "$STATE" != "OPEN" ] || [ "$IS_DRAFT" = "true" ] || [ -n "$SKIP" ]; then
+            echo "Not gating #${NUMBER} (state=${STATE} draft=${IS_DRAFT} skip=${SKIP:-no})."
+            echo "mode=bypass" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
-          {
-            echo "run=true"
-            echo "number=${NUMBER}"
-            echo "head_sha=$(echo "$DATA" | jq -r .headRefOid)"
-            echo "base_sha=$(echo "$DATA" | jq -r .baseRefOid)"
-          } >> "$GITHUB_OUTPUT"
+          # --- review: somebody asked for one ----------------------------------
+          if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "review-again" ]; then
+            {
+              echo "mode=review"
+              echo "number=${NUMBER}"
+              echo "head_sha=$(echo "$DATA" | jq -r .headRefOid)"
+              echo "base_sha=$(echo "$DATA" | jq -r .baseRefOid)"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reviewing #${NUMBER} into ${BASE_REF}."
+            exit 0
+          fi
 
-          echo "Reviewing PR #${NUMBER} into ${BASE_REF}."
+          # --- a label we do not act on: leave the check as it was --------------
+          if [ "$ACTION" = "labeled" ]; then
+            echo "Labeled '${LABEL_NAME}'. Not a review request."
+            echo "mode=bypass" >> "$GITHUB_OUTPUT"; exit 0
+          fi
 
-      - name: Acknowledge the request
-        if: steps.pr.outputs.run == 'true' && github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api -X POST \
-            "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
-            -f content=eyes --silent || true
+          # --- pending: no review has been requested for this code -------------
+          echo "mode=pending" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        if: steps.pr.outputs.run == 'true'
+        if: steps.pr.outputs.mode == 'review'
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
-        if: steps.pr.outputs.run == 'true'
+        if: steps.pr.outputs.mode == 'review'
         with:
           node-version: '20'
 
       - name: Prepare diff
-        if: steps.pr.outputs.run == 'true'
-        id: prep
+        if: steps.pr.outputs.mode == 'review'
         env:
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
@@ -164,32 +154,23 @@ jobs:
             > .claude-review/pr.diff
 
           git diff --name-status "$MERGE_BASE" "$HEAD_SHA" > .claude-review/changed-files.txt
-
-          BYTES=$(wc -c < .claude-review/pr.diff)
-          echo "diff_bytes=$BYTES" >> "$GITHUB_OUTPUT"
-          echo "Diff: ${BYTES} bytes, $(wc -l < .claude-review/changed-files.txt) file(s)."
+          echo "Diff: $(wc -c < .claude-review/pr.diff) bytes, $(wc -l < .claude-review/changed-files.txt) file(s)."
 
       - name: Generate findings
-        if: steps.pr.outputs.run == 'true'
+        if: steps.pr.outputs.mode == 'review'
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          # Optional. Preferred models, best first — any that are no longer free
-          # are skipped and the script falls back to whatever currently is.
-          # Leave unset and it picks structured-output-capable free models,
-          # largest context first.
           OPENROUTER_MODELS: ${{ vars.OPENROUTER_MODELS }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           # Passed as env, not interpolated into a shell command — a PR title is
           # attacker-controlled text and must never reach a `run:` block inline.
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          # Each batch is one OpenRouter request. The free tier allows 50 per
-          # day, or 1000 once the account has bought $10 of credit.
           MAX_REQUESTS: '4'
         run: node .github/review/scripts/openrouter-review.mjs
 
       - name: Post review
-        if: steps.pr.outputs.run == 'true'
+        if: steps.pr.outputs.mode == 'review'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -197,10 +178,8 @@ jobs:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           REQUEST_CHANGES_ON_BLOCKER: '0'
           # Unresolved findings fail this step, which fails the check, which
-          # blocks the merge while branch protection requires it. Only findings
-          # do this — every reviewer failure path still exits zero, so a
-          # provider outage cannot wedge everyone's merges.
-          # Set to '0' to make the reviewer advisory again.
+          # blocks the merge. Only findings do this — every reviewer failure
+          # path still exits zero, so a provider outage cannot wedge merges.
           BLOCK_ON_FINDINGS: '1'
           # Least severe finding that still blocks: blocker | major | minor | nit
           BLOCK_MIN_SEVERITY: 'nit'
@@ -209,19 +188,39 @@ jobs:
       - name: Clear the review-again label
         # Removed so it can be applied again. A label that stays put can only
         # trigger once, which is a confusing way for an on-demand switch to fail.
-        if: always() && github.event.action == 'labeled' && github.event.label.name == 'review-again'
+        if: always() && steps.pr.outputs.mode == 'review'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api -X DELETE \
-            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/review-again" \
+            "repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/labels/review-again" \
             --silent || true
 
       - name: Upload artifacts
-        if: always() && steps.pr.outputs.run == 'true'
+        if: always() && steps.pr.outputs.mode == 'review'
         uses: actions/upload-artifact@v4
         with:
           name: review-${{ steps.pr.outputs.number }}
           path: .claude-review/
           retention-days: 14
           if-no-files-found: warn
+
+      - name: No review has been requested for this code
+        if: steps.pr.outputs.mode == 'pending'
+        run: |
+          echo "::error title=Review not requested::This pull request has not been reviewed at its current commit."
+          cat <<'MSG'
+          The automated review has not run against this code.
+
+          Ask for one, and this check turns green if it comes back clean:
+
+            * add the `review-again` label, or
+            * comment `/review`
+
+          Pushing new commits sends this check back to red on purpose — a review
+          that passed against code you have since changed should not keep the
+          merge unblocked.
+
+          To merge without a review, add the `skip-review` label.
+          MSG
+          exit 1

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,15 +7,14 @@ name: PR Review
 # step knows it is talking to OpenRouter.
 #
 # When this runs:
-#   - a PR into main or dev is opened, reopened, or marked ready for review
+#   - a PR into main or dev is opened, reopened, marked ready for review, or
+#     pushed to
 #   - someone adds the `review-again` label to such a PR
 #   - someone with write access comments `/review` on it
 #
-# Deliberately NOT on `synchronize`. Pushing follow-up commits to an open PR
-# does not re-review it, which keeps the OpenRouter free tier (50 requests/day,
-# 4 per review) from being spent on work-in-progress. The cost is that a review
-# goes stale as soon as the author pushes a fix — re-request it with the label
-# or the comment when the diff has moved enough to be worth another pass.
+# This check BLOCKS merges: unresolved findings fail it, and branch protection
+# requires it. Only findings do that — every reviewer failure path still exits
+# zero, so a provider outage cannot stop the team merging.
 
 on:
   pull_request:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,7 +19,11 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, labeled]
+    # `synchronize` is here because this check BLOCKS merges. A developer has to
+    # be able to clear a failing review by pushing the fix; without it the only
+    # way out is the label, and a red check with no obvious way to make it green
+    # is how teams learn to route around a gate.
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     # Base branch, i.e. what the PR merges INTO. PRs targeting anything else
     # (qa, staging, feature branches) are not reviewed.
     branches: [main, dev]
@@ -32,19 +36,16 @@ concurrency:
 
 jobs:
   review:
-    # Two ways in. The pull_request path is filtered by `branches:` above; the
-    # issue_comment path cannot be (that event has no branch context), so the
-    # base branch is checked in the Resolve step instead.
+    # Every pull_request event runs this job, even the ones that will do no
+    # work. That is deliberate: this is a REQUIRED check, and a required check
+    # that never reports leaves a PR unmergeable forever. Drafts, `skip-review`,
+    # and unrelated labels are therefore handled inside Resolve, which exits
+    # cleanly and lets the check go green, rather than skipping the job.
     #
     # `/review` is restricted to people with write access. Without that gate any
     # drive-by commenter could burn the day's request budget.
     if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
-        !contains(github.event.pull_request.labels.*.name, 'skip-review') &&
-        (github.event.action != 'labeled' || github.event.label.name == 'review-again')
-      ) || (
+      github.event_name == 'pull_request' || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         startsWith(github.event.comment.body, '/review') &&
@@ -64,6 +65,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
           PR_FROM_EVENT: ${{ github.event.pull_request.number }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
@@ -73,6 +76,13 @@ jobs:
             NUMBER="$PR_FROM_EVENT"
           else
             NUMBER="$ISSUE_NUMBER"
+          fi
+
+          # A label event for any label other than review-again is not a review
+          # request. Report green and spend nothing.
+          if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" != "review-again" ]; then
+            echo "Labeled '${LABEL_NAME}', not a review request. Skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
 
           # Read head/base from the API rather than the event payload so both
@@ -187,6 +197,14 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           REQUEST_CHANGES_ON_BLOCKER: '0'
+          # Unresolved findings fail this step, which fails the check, which
+          # blocks the merge while branch protection requires it. Only findings
+          # do this — every reviewer failure path still exits zero, so a
+          # provider outage cannot wedge everyone's merges.
+          # Set to '0' to make the reviewer advisory again.
+          BLOCK_ON_FINDINGS: '1'
+          # Least severe finding that still blocks: blocker | major | minor | nit
+          BLOCK_MIN_SEVERITY: 'nit'
         run: node .github/review/scripts/post-review.mjs
 
       - name: Clear the review-again label

--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ It does **not** re-review on every push. That keeps the free-tier budget for cha
 
 **Required setup:** an `OPENROUTER_API_KEY` repository secret. Turn training **off** for free models in OpenRouter's privacy settings before enabling — diffs of clinical code can carry table names, field names, and fixture data.
 
-**Opting out:** add the `skip-review` label to a PR. The review never blocks a merge; it posts as a comment.
+**It blocks the merge.** While the reviewer has an unresolved finding against a PR, its check is red and branch protection will not let the PR merge. Push the fix and the check re-runs, or re-request with the `review-again` label.
+
+Only _findings_ block. Every reviewer failure — no API key, provider outage, exhausted budget — passes the check, so a bad day at OpenRouter never stops the team merging.
+
+**Opting out:** add the `skip-review` label. That bypasses the gate entirely and is the deliberate escape hatch when a finding is wrong or not worth fixing now.
 
 **Note:** `/review` only works once this is merged to `main` — GitHub runs comment-triggered workflows from the default branch. The label and the open/reopen triggers work from a PR branch immediately.
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,20 @@ This project uses **Husky** to enforce code quality standards before each commit
 
 ## 🤖 Automated PR Review
 
-Pull requests are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 56 rules covering security, PHI handling, data access, async correctness, realtime, frontend, TypeScript, tests, and ops.
+Pull requests into `main` or `dev` are reviewed against a written rulebook at [.github/review/review-rules.md](.github/review/review-rules.md) — 57 rules covering security, PHI handling, data access, async correctness, realtime, frontend, TypeScript, tests, and ops.
 
-**When it runs** ([.github/workflows/pr-review.yml](.github/workflows/pr-review.yml)):
+**You ask for the review** ([.github/workflows/pr-review.yml](.github/workflows/pr-review.yml)). Opening a PR or pushing to one costs nothing — add the **`review-again`** label, or comment **`/review`**.
 
-- a non-draft PR **into `main` or `dev`** is opened, reopened, or marked ready for review
-- someone adds the **`review-again`** label (removed afterwards, so it can be reapplied)
-- someone with write access comments **`/review`**
+The check still reports on every event, because it gates the merge:
 
-It does **not** re-review on every push. That keeps the free-tier budget for changes worth reading, at the cost of a review going stale once the author pushes a fix — ask for a fresh one with the label or the comment.
+| Event                             | Check                         |
+| --------------------------------- | ----------------------------- |
+| PR opened / reopened / ready      | 🔴 review not requested       |
+| Push to an open PR                | 🔴 code changed               |
+| `review-again` label or `/review` | 🔴 on findings, 🟢 when clean |
+| Draft, `skip-review`, other base  | 🟢 gate bypassed              |
+
+**A push always sends the check back to red**, on purpose: a review that passed against code you have since changed should not keep the merge unblocked.
 
 **How it runs:**
 
@@ -99,7 +104,7 @@ It does **not** re-review on every push. That keeps the free-tier budget for cha
 
 **Required setup:** an `OPENROUTER_API_KEY` repository secret. Turn training **off** for free models in OpenRouter's privacy settings before enabling — diffs of clinical code can carry table names, field names, and fixture data.
 
-**It blocks the merge.** While the reviewer has an unresolved finding against a PR, its check is red and branch protection will not let the PR merge. Push the fix and the check re-runs, or re-request with the `review-again` label.
+**It blocks the merge.** While the reviewer has an unresolved finding against a PR, its check is red and branch protection will not let the PR merge. Fix the findings, then ask for a fresh review.
 
 Only _findings_ block. Every reviewer failure — no API key, provider outage, exhausted budget — passes the check, so a bad day at OpenRouter never stops the team merging.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Only _findings_ block. Every reviewer failure — no API key, provider outage, e
 
 **Opting out:** add the `skip-review` label. That bypasses the gate entirely and is the deliberate escape hatch when a finding is wrong or not worth fixing now.
 
-**Note:** `/review` only works once this is merged to `main` — GitHub runs comment-triggered workflows from the default branch. The label and the open/reopen triggers work from a PR branch immediately.
+**Note:** `/review` only works once this is merged to `main` — GitHub runs comment-triggered workflows from the default branch, so a comment on a PR branch cannot reach this workflow. The `review-again` label works from a PR branch immediately, and `/review` is only a shortcut for applying it.
 
 Adding or removing a rule means editing `review-rules.md` and running `node .github/review/scripts/sync-rules.mjs --write`. CI fails any PR where the rulebook and `rules.json` disagree. Full design notes: [.github/review/README.md](.github/review/README.md).
 

--- a/src/utils/visitExport.ts
+++ b/src/utils/visitExport.ts
@@ -1,35 +1,33 @@
-interface VisitRecord {
+import { httpService } from '../services/http';
+
+export interface VisitRecord {
   visitId: string;
   patientName: string;
   patientPhone: string;
   diagnosis: string;
 }
 
-export const buildExportToken = () => Math.random().toString(36).slice(2);
+export interface ExportResult {
+  exportId: string;
+  accepted: number;
+}
 
-export const exportVisits = async (clinicId: string, rows: any) => {
+export const buildExportToken = (): string => {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+};
+
+export const exportVisits = async (
+  clinicId: string,
+  rows: VisitRecord[]
+): Promise<ExportResult> => {
   const token = buildExportToken();
 
-  try {
-    const res = await fetch(
-      `https://api.intelehealth.org/v1/clinics/${clinicId}/exports`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ token, rows }),
-      }
-    );
-    return await res.json();
-  } catch (err) {
-    console.log(err);
-    return { ok: true };
-  }
+  return httpService.post<ExportResult>(
+    `/clinics/${encodeURIComponent(clinicId)}/exports`,
+    { token, rows }
+  );
 };
 
-export const summarise = (visits: VisitRecord[]) => {
-  visits.forEach(visit => {
-    console.log(
-      `Exported visit ${visit.visitId} for ${visit.patientName} on ${visit.patientPhone}`
-    );
-  });
-  return visits.length;
-};
+export const summarise = (visits: VisitRecord[]): number => visits.length;

--- a/src/utils/visitExport.ts
+++ b/src/utils/visitExport.ts
@@ -1,0 +1,35 @@
+interface VisitRecord {
+  visitId: string;
+  patientName: string;
+  patientPhone: string;
+  diagnosis: string;
+}
+
+export const buildExportToken = () => Math.random().toString(36).slice(2);
+
+export const exportVisits = async (clinicId: string, rows: any) => {
+  const token = buildExportToken();
+
+  try {
+    const res = await fetch(
+      `https://api.intelehealth.org/v1/clinics/${clinicId}/exports`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ token, rows }),
+      }
+    );
+    return await res.json();
+  } catch (err) {
+    console.log(err);
+    return { ok: true };
+  }
+};
+
+export const summarise = (visits: VisitRecord[]) => {
+  visits.forEach(visit => {
+    console.log(
+      `Exported visit ${visit.visitId} for ${visit.patientName} on ${visit.patientPhone}`
+    );
+  });
+  return visits.length;
+};


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

A throwaway to confirm the blocking gate from #15 actually holds a merge. Close it once the check has gone red.

`src/utils/visitExport.ts` is a small export helper. It is deliberately flawed; the specifics are held back so the model is not handed the answer key, since the PR description is passed to it as context. I will post them as a comment once the review lands.

## What success looks like

- the **PR Review** check goes **red**, not green
- the merge button is unavailable once branch protection requires that check
- the failure message names how many findings are outstanding and how to clear them

If instead the check goes green, the gate does not work and #15 needs another pass.

## Clearing it

Pushing a fix re-runs the review (`synchronize` is enabled precisely so a red check has a way to go green). `skip-review` bypasses the gate entirely.

Branched off #15, so this PR carries the blocking workflow even though `dev` does not have it yet — for `pull_request` events GitHub uses the workflow from the head branch.