### PR TITLE
fix(review): make the reviewer's own output debuggable

### DIFF
--- a/.github/review/scripts/openrouter-review.mjs
+++ b/.github/review/scripts/openrouter-review.mjs
@@ -385,6 +385,12 @@ async function main() {
       `Batch ${i + 1}/${chunks.length} via ${result.model}: ` +
         `${findings.length} finding(s) kept, ${rejected.length} rejected.`
     );
+    // A rejected finding means the model DID find something and we discarded
+    // it. That is a very different problem from the model finding nothing, so
+    // say why here rather than only in an artifact.
+    for (const reason of [...new Set(rejected)].slice(0, 10)) {
+      console.log(`   rejected: ${reason}`);
+    }
     debug.push({
       batch: i + 1,
       files: chunkFiles,

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -204,6 +204,10 @@ jobs:
           path: .claude-review/
           retention-days: 14
           if-no-files-found: warn
+          # .claude-review is a dot-directory, and upload-artifact@v4 skips
+          # hidden paths by default — without this the artifact is silently
+          # empty, which is how every review so far uploaded nothing.
+          include-hidden-files: true
 
       - name: No review has been requested for this code
         if: steps.pr.outputs.mode == 'pending'


### PR DESCRIPTION
Found while diagnosing why `deepseek-v4-pro` produced 6 findings on #16 that were all discarded.

**Artifacts have never uploaded.** `upload-artifact@v4` skips hidden paths by default and `.claude-review` is a dot-directory, so every review so far uploaded nothing — warning about it in a step that still reported `success`. That's why `gh run download` kept returning "no valid artifacts found".

**Rejection reasons were never logged.** The batch line printed only counts. `0 kept, 4 rejected` and `0 kept, 0 rejected` look almost identical but mean opposite things — the first is the model working and us discarding its output, the second is the model giving up. The reasons now print to the console, so this is diagnosable from the run log without depending on an artifact.

No behaviour change to reviewing or gating.